### PR TITLE
LPS-22736 - difference in stored pinned value ("1") and tested pinned value ("true")

### DIFF
--- a/portal-web/docroot/html/js/liferay/dockbar.js
+++ b/portal-web/docroot/html/js/liferay/dockbar.js
@@ -404,7 +404,7 @@ AUI.add(
 							themeDisplay.getPathMain() + '/portal/session_click',
 							{
 								data: {
-									'liferay_dockbar_pinned': pinned
+									'liferay_dockbar_pinned': pinned ? 'true' : 'false'
 								}
 							}
 						);


### PR DESCRIPTION
dockbar.js was sending '1' in HTTP param 'liferay_dockbar_pinned', but all default themes tested equality to String "true", when deciding wheater Dockbar is pinned or not
