### PR TITLE
LPS-25197 - 'portalURL' in 'serviceContext' object should not contain any path

### DIFF
--- a/portal-service/src/com/liferay/portal/service/ServiceContextFactory.java
+++ b/portal-service/src/com/liferay/portal/service/ServiceContextFactory.java
@@ -74,10 +74,7 @@ public class ServiceContextFactory {
 					themeDisplay.getLayout()));
 			serviceContext.setPathMain(PortalUtil.getPathMain());
 			serviceContext.setPlid(themeDisplay.getPlid());
-			serviceContext.setPortalURL(
-				PortalUtil.getCanonicalURL(
-					PortalUtil.getPortalURL(request), themeDisplay,
-					themeDisplay.getLayout()));
+			serviceContext.setPortalURL(PortalUtil.getPortalURL(request));
 			serviceContext.setScopeGroupId(themeDisplay.getScopeGroupId());
 			serviceContext.setSignedIn(themeDisplay.isSignedIn());
 


### PR DESCRIPTION
- PortalUtil.getCanonicalURL() appends path from themeDisplay
- 'serviceContext.fullLayoutURL' and 'serviceContext.layoutURL' already contain the path
