### PR TITLE
LPS-22360 Move Portal Mobile Device Rules to the Group Global Scope

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -1882,23 +1882,9 @@
 		<css-class-wrapper>license-manager</css-class-wrapper>
 	</portlet>
 	<portlet>
-		<portlet-name>177</portlet-name>
-		<icon>/html/icons/default.png</icon>
-		<struts-path>mobile_device_rules</struts-path>
-		<portlet-url-class>com.liferay.portal.struts.StrutsActionPortletURL</portlet-url-class>
-		<control-panel-entry-category>portal</control-panel-entry-category>
-		<control-panel-entry-weight>13.0</control-panel-entry-weight>
-		<use-default-template>false</use-default-template>
-		<private-request-attributes>false</private-request-attributes>
-		<private-session-attributes>false</private-session-attributes>
-		<render-weight>50</render-weight>
-		<header-portlet-css>/html/portlet/mobile_device_rules/css/main.css</header-portlet-css>
-		<css-class-wrapper>mobile-device-rules</css-class-wrapper>
-	</portlet>
-	<portlet>
 		<portlet-name>178</portlet-name>
 		<icon>/html/icons/default.png</icon>
-		<parent-struts-path>mobile_device_rules</parent-struts-path>
+		<struts-path>mobile_device_rules</struts-path>
 		<portlet-url-class>com.liferay.portal.struts.StrutsActionPortletURL</portlet-url-class>
 		<portlet-data-handler-class>com.liferay.portlet.mobiledevicerules.lar.MDRPortletDataHandlerImpl</portlet-data-handler-class>
 		<control-panel-entry-category>content</control-panel-entry-category>


### PR DESCRIPTION
Hi Mike,
it seams the porlet works fine in the Global scope already, so I just removed the instance in "portal" section from liferay-portlet.xml. Do you think that's OK.
