### PR TITLE
LPS-55712 Add groupId to DataSample objects

### DIFF
--- a/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/BaseDataSample.java
+++ b/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/BaseDataSample.java
@@ -69,6 +69,11 @@ public class BaseDataSample implements DataSample, Serializable {
 	}
 
 	@Override
+	public long getGroupId() {
+		return _groupId;
+	}
+
+	@Override
 	public String getName() {
 		return _name;
 	}
@@ -118,6 +123,11 @@ public class BaseDataSample implements DataSample, Serializable {
 	}
 
 	@Override
+	public void setGroupId(long groupId) {
+		_groupId = groupId;
+	}
+
+	@Override
 	public void setName(String name) {
 		_name = name;
 	}
@@ -139,12 +149,14 @@ public class BaseDataSample implements DataSample, Serializable {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(19);
+		StringBundler sb = new StringBundler(21);
 
 		sb.append("{attributes=");
 		sb.append(_attributes);
 		sb.append(", companyId=");
 		sb.append(_companyId);
+		sb.append(", groupId=");
+		sb.append(_groupId);
 		sb.append(", description=");
 		sb.append(_description);
 		sb.append(", duration=");
@@ -170,6 +182,7 @@ public class BaseDataSample implements DataSample, Serializable {
 	private long _companyId;
 	private String _description;
 	private long _duration;
+	private long _groupId;
 	private String _name;
 	private String _namespace;
 	private RequestStatus _requestStatus;

--- a/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/DataSampleFactoryImpl.java
+++ b/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/DataSampleFactoryImpl.java
@@ -35,11 +35,11 @@ public class DataSampleFactoryImpl implements DataSampleFactory {
 
 	@Override
 	public DataSample createPortalRequestDataSample(
-		long companyId, String remoteUser, String requestURI,
+		long companyId, long groupId, String remoteUser, String requestURI,
 		String requestURL) {
 
 		return new PortalRequestDataSample(
-			companyId, remoteUser, requestURI, requestURL);
+			companyId, groupId, remoteUser, requestURI, requestURL);
 	}
 
 	@Override

--- a/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/servlet/taglib/MonitoringTopHeadDynamicInclude.java
+++ b/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/servlet/taglib/MonitoringTopHeadDynamicInclude.java
@@ -58,8 +58,8 @@ public class MonitoringTopHeadDynamicInclude extends BaseDynamicInclude {
 
 		DataSample dataSample =
 			_dataSampleFactory.createPortalRequestDataSample(
-				themeDisplay.getCompanyId(), request.getRemoteUser(),
-				request.getRequestURI(),
+				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
+				request.getRemoteUser(), request.getRequestURI(),
 				request.getRequestURL().toString() + ".jsp_display");
 
 		dataSample.setDescription("Portal Request");

--- a/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/statistics/portal/PortalRequestDataSample.java
+++ b/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/statistics/portal/PortalRequestDataSample.java
@@ -26,9 +26,11 @@ import com.liferay.portal.monitoring.internal.BaseDataSample;
 public class PortalRequestDataSample extends BaseDataSample {
 
 	public PortalRequestDataSample(
-		long companyId, String user, String requestURI, String requestURL) {
+		long companyId, long groupId, String user, String requestURI,
+		String requestURL) {
 
 		setCompanyId(companyId);
+		setGroupId(groupId);
 		setUser(user);
 		setNamespace(MonitorNames.PORTAL);
 		setName(requestURI);

--- a/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/statistics/portlet/PortletRequestDataSample.java
+++ b/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/statistics/portlet/PortletRequestDataSample.java
@@ -14,12 +14,16 @@
 
 package com.liferay.portal.monitoring.internal.statistics.portlet;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.monitoring.PortletRequestType;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.monitoring.MonitorNames;
 import com.liferay.portal.monitoring.internal.BaseDataSample;
+import com.liferay.portal.util.PortalUtil;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
@@ -41,6 +45,14 @@ public class PortletRequestDataSample extends BaseDataSample {
 		Portlet portlet = liferayPortletResponse.getPortlet();
 
 		setCompanyId(portlet.getCompanyId());
+
+		try {
+			setGroupId(PortalUtil.getScopeGroupId(portletRequest));
+		}
+		catch (PortalException e) {
+			_log.error(e);
+		}
+
 		setUser(portletRequest.getRemoteUser());
 		setNamespace(MonitorNames.PORTLET);
 		setName(portlet.getPortletName());
@@ -77,6 +89,9 @@ public class PortletRequestDataSample extends BaseDataSample {
 
 		return sb.toString();
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortletRequestDataSample.class);
 
 	private final String _displayName;
 	private final String _portletId;

--- a/portal-impl/src/com/liferay/portal/monitoring/statistics/DataSampleFactoryUtil.java
+++ b/portal-impl/src/com/liferay/portal/monitoring/statistics/DataSampleFactoryUtil.java
@@ -34,11 +34,11 @@ import javax.portlet.PortletResponse;
 public class DataSampleFactoryUtil {
 
 	public static DataSample createPortalRequestDataSample(
-		long companyId, String remoteUser, String requestURI,
+		long companyId, long groupId, String remoteUser, String requestURI,
 		String requestURL) {
 
 		return _getDataSampleFactory().createPortalRequestDataSample(
-			companyId, remoteUser, requestURI, requestURL);
+			companyId, groupId, remoteUser, requestURI, requestURL);
 	}
 
 	public static DataSample createPortletRequestDataSample(

--- a/portal-service/src/com/liferay/portal/kernel/monitoring/DataSample.java
+++ b/portal-service/src/com/liferay/portal/kernel/monitoring/DataSample.java
@@ -26,9 +26,13 @@ public interface DataSample {
 
 	public Map<String, String> getAttributes();
 
+	public long getCompanyId();
+
 	public String getDescription();
 
 	public long getDuration();
+
+	public long getGroupId();
 
 	public String getName();
 
@@ -48,12 +52,14 @@ public interface DataSample {
 
 	public void setDescription(String description);
 
+	public void setGroupId(long groupId);
+
 	public void setName(String name);
 
 	public void setNamespace(String namespace);
 
 	public void setTimeout(long timeout);
 
-	public void setUser(String user); public long getCompanyId();
+	public void setUser(String user);
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/monitoring/DataSampleFactory.java
+++ b/portal-service/src/com/liferay/portal/kernel/monitoring/DataSampleFactory.java
@@ -23,7 +23,7 @@ import javax.portlet.PortletResponse;
 public interface DataSampleFactory {
 
 	public DataSample createPortalRequestDataSample(
-		long companyId, String remoteUser, String requestURI,
+		long companyId, long groupId, String remoteUser, String requestURI,
 		String requestURL);
 
 	public DataSample createPortletRequestDataSample(


### PR DESCRIPTION
Hi Mike,

This wants to add the groupId to the DataSample objects. The MonitoringFilter is kicked twice per page request. The second time is after the FriendlyURLServlet that is setting the p_l_id. 
After discussing it with Ivica it is intended, by this commit, to leave the first MonitoringFilter call with an empty groupId (for PortalRequestDataSample objects)

Thanks