### PR TITLE
LPS-56530 Unit tests documenting regressions and bugs

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
@@ -105,6 +105,27 @@ public class DDLRecordSearchTest {
 	}
 
 	@Test
+	public void testExactPhraseMixedWithWords() throws Exception {
+		Assume.assumeTrue(isExactPhraseQueryImplementedForSearchEngine());
+
+		addRecord("One Two Three Four Five Six", RandomTestUtil.randomString());
+		addRecord(RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		assertSearch("\"Two Three\" Five", 1);
+		assertSearch("\"Two Three\" Nine", 1);
+		assertSearch("\"Two  Four\" Five", 1);
+		assertSearch("\"Two  Four\" Nine", 0);
+		assertSearch("Three \"Five Six\"", 1);
+		assertSearch("Zero  \"Five Six\"", 1);
+		assertSearch("Three \"Four Six\"", 1);
+		assertSearch("Zero  \"Four Six\"", 0);
+		assertSearch("One  \"Three Four\" Six ", 1);
+		assertSearch("Zero \"Three Four\" Nine", 1);
+		assertSearch("One  \"Three Five\" Six ", 1);
+		assertSearch("Zero \"Three Five\" Nine", 0);
+	}
+
+	@Test
 	public void testPunctuationInExactPhrase() throws Exception {
 		Assume.assumeTrue(isExactPhraseQueryImplementedForSearchEngine());
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.Group;
@@ -303,16 +304,14 @@ public class DDLRecordSearchTest {
 	}
 
 	protected boolean isExactPhraseQueryImplementedForSearchEngine() {
+		return isSearchEngineVendor("Solr");
+	}
+
+	protected boolean isSearchEngineVendor(String... vendors) {
 		SearchEngine searchEngine = SearchEngineUtil.getSearchEngine(
 			SearchEngineUtil.getDefaultSearchEngineId());
 
-		String vendor = searchEngine.getVendor();
-
-		if (vendor.equals("Lucene") || vendor.equals("SOLR")) {
-			return true;
-		}
-
-		return false;
+		return ArrayUtil.contains(vendors, searchEngine.getVendor(), true);
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/search/test/WikiPageSearchTest.java
+++ b/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/search/test/WikiPageSearchTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.BaseModel;
@@ -288,17 +289,15 @@ public class WikiPageSearchTest extends BaseSearchTestCase {
 					getBaseModelClass(), group.getGroupId(), searchContext));
 		}
 
-		protected boolean isSearchSpecificFieldsImplementedForSearchEngine() {
+		protected boolean isSearchEngineVendor(String... vendors) {
 			SearchEngine searchEngine = SearchEngineUtil.getSearchEngine(
 				SearchEngineUtil.getDefaultSearchEngineId());
 
-			String vendor = searchEngine.getVendor();
+			return ArrayUtil.contains(vendors, searchEngine.getVendor(), true);
+		}
 
-			if (vendor.equals("Lucene")) {
-				return true;
-			}
-
-			return false;
+		protected boolean isSearchSpecificFieldsImplementedForSearchEngine() {
+			return !isSearchEngineVendor("Elasticsearch", "Solr");
 		}
 
 		private final BaseModel<?> _parentBaseModel;

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngine;
+import com.liferay.portal.kernel.search.SearchEngineUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
@@ -26,6 +28,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -64,6 +67,7 @@ import com.liferay.portlet.dynamicdatamapping.util.test.DDMStructureTestUtil;
 import java.io.File;
 import java.io.InputStream;
 
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -180,6 +184,22 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 	@Override
 	@Test
 	public void testSearchAttachments() throws Exception {
+	}
+
+	@Override
+	@Test
+	public void testSearchByDDMStructureField() throws Exception {
+		Assume.assumeTrue(isBrokenOnSolrAfterLPS56530());
+
+		super.testSearchByDDMStructureField();
+	}
+
+	@Override
+	@Test
+	public void testSearchStatus() throws Exception {
+		Assume.assumeTrue(isBrokenOnSolrAfterLPS56530());
+
+		super.testSearchStatus();
 	}
 
 	@Test
@@ -381,9 +401,20 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		return "Title";
 	}
 
+	protected boolean isBrokenOnSolrAfterLPS56530() {
+		return !isSearchEngineVendor("Solr");
+	}
+
 	@Override
 	protected boolean isExpirableAllVersions() {
 		return true;
+	}
+
+	protected boolean isSearchEngineVendor(String... vendors) {
+		SearchEngine searchEngine = SearchEngineUtil.getSearchEngine(
+			SearchEngineUtil.getDefaultSearchEngineId());
+
+		return ArrayUtil.contains(vendors, searchEngine.getVendor(), true);
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
@@ -120,6 +120,19 @@ public class UserIndexerTest {
 	}
 
 	@Test
+	public void testFirstNameExactPhrase() throws Exception {
+		String firstName = "Mary Jane";
+		String middleName = "Watson";
+		String lastName = "Parker";
+
+		addUserNameFields(firstName, lastName, middleName);
+
+		User user = assertSearchOneUser("firstName", "\"Mary Jane\"");
+
+		Assert.assertEquals(firstName, user.getFirstName());
+	}
+
+	@Test
 	public void testLikeCharacter() throws Exception {
 		Assume.assumeTrue(isEmptyQueryImplementedForSearchEngine());
 

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
@@ -400,7 +400,7 @@ public class UserIndexerTest {
 	}
 
 	protected boolean isAPIWithoutQueryParserImplementedForSearchEngine() {
-		return !isSearchEngineVendor("Solr");
+		return !isSearchEngineVendor("Elasticsearch", "Solr");
 	}
 
 	protected boolean isEmptyQueryImplementedForSearchEngine() {

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
@@ -247,6 +247,15 @@ public class UserIndexerTest {
 		Assert.assertEquals("open4life", user.getScreenName());
 	}
 
+	@Test
+	public void testScreenNameTwoWords() throws Exception {
+		addUserScreenName("Open4Life");
+
+		User user = assertSearchOneUser("screenName", "open lite");
+
+		Assert.assertEquals("open4life", user.getScreenName());
+	}
+
 	protected User addUser() throws Exception {
 		User user = UserTestUtil.addUser();
 

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
@@ -145,9 +145,6 @@ public class UserIndexerTest {
 
 	@Test
 	public void testNameFieldsNotTokenized() throws Exception {
-		Assume.assumeTrue(
-			isCaseInsensitiveNameFieldsImplementedForSearchEngine());
-
 		String firstName = "Liferay7";
 		String lastName = "dell'Apostrophe";
 		String middleName = "ALLOY_4";
@@ -166,9 +163,6 @@ public class UserIndexerTest {
 
 	@Test
 	public void testNamesPrefix() throws Exception {
-		Assume.assumeTrue(
-			isCaseInsensitiveNameFieldsImplementedForSearchEngine());
-
 		String firstName = "First";
 		String lastName = "Last";
 		String middleName = "Middle";
@@ -190,8 +184,6 @@ public class UserIndexerTest {
 
 	@Test
 	public void testNamesSubstring() throws Exception {
-		Assume.assumeTrue(
-			isCaseInsensitiveNameFieldsImplementedForSearchEngine());
 		Assume.assumeTrue(
 			isTwoEndedSubstringSearchImplementedForSearchEngine());
 
@@ -386,11 +378,7 @@ public class UserIndexerTest {
 	}
 
 	protected boolean isAPIWithoutQueryParserImplementedForSearchEngine() {
-		return !isSearchEngineVendor("Lucene", "Solr");
-	}
-
-	protected boolean isCaseInsensitiveNameFieldsImplementedForSearchEngine() {
-		return !isSearchEngineVendor("Lucene");
+		return !isSearchEngineVendor("Solr");
 	}
 
 	protected boolean isEmptyQueryImplementedForSearchEngine() {


### PR DESCRIPTION
The last 2 commits ("REGRESSION") are supposed to be discarded. They're there just to signal which tests went red because of LPS-56530. The tests should go green after fixes.

The second-to-last 2 commits ("replicates bug") are genuine. Either we fix them now, or we suppress the tests if we decide to fix them later as part of the upcoming wildcard fields rewrite.