### PR TITLE
Lps 56513 Move MultiVMPool/SingleVMPool service out to bundle

### DIFF
--- a/modules/build.xml
+++ b/modules/build.xml
@@ -58,7 +58,7 @@
 		<dirset dir="apps/xsl-content" includes="*" />
 		<dirset dir="core" includes="*" />
 		<dirset dir="frontend" includes="*" />
-		<dirset dir="portal" excludes="portal-search-solr,portal-taglib-aui-form-extension-sample" includes="*" />
+		<dirset dir="portal" excludes="portal-cache-memory,portal-search-solr,portal-taglib-aui-form-extension-sample" includes="*" />
 		<dirset dir="portal-security" includes="*" />
 		<dirset dir="util" includes="pmd,portal-tools-sample-sql-builder,sass-compiler-jni" />
 	</path>

--- a/modules/portal/portal-cache/.classpath
+++ b/modules/portal/portal-cache/.classpath
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<classpath>
+	<classpathentry excluding="**/.svn/**|.svn/" kind="src" path="src" />
+	<classpathentry kind="src" path="/portal-master" />
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER" />
+	<classpathentry excluding="**/.svn/**|.svn/" kind="src" path="test/unit" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/junit.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/mockito.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-api-mockito.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-api-support.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-core.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-module-junit4.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-module-junit4-common.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/spring-test.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/activation.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/annotations.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/jsp-api.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/mail.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/servlet-api.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/global/portlet.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/bnd.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/commons-io.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/commons-lang.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/commons-logging.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/log4j.jar" />
+	<classpathentry kind="lib" path="/portal-master/portal-service/portal-service.jar" />
+	<classpathentry kind="lib" path="/portal-master/util-bridges/util-bridges.jar" />
+	<classpathentry kind="lib" path="/portal-master/util-java/util-java.jar" />
+	<classpathentry kind="lib" path="/portal-master/util-taglib/util-taglib.jar" />
+	<classpathentry kind="lib" path="lib/org.osgi.compendium.jar" />
+	<classpathentry kind="lib" path="lib/org.osgi.core.jar" />
+	<classpathentry kind="lib" path="lib/slf4j-api.jar" />
+	<classpathentry kind="output" path="bin" />
+</classpath>

--- a/modules/portal/portal-cache/.project
+++ b/modules/portal/portal-cache/.project
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<projectDescription>
+	<name>portal-cache-master</name>
+	<comment></comment>
+	<projects></projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments></arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/modules/portal/portal-cache/bnd.bnd
+++ b/modules/portal/portal-cache/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Portal Cache
+Bundle-SymbolicName: com.liferay.portal.cache
+Bundle-Version: 1.0.0
+Include-Resource:classes

--- a/modules/portal/portal-cache/build.xml
+++ b/modules/portal/portal-cache/build.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../tools/sdk/build-common-osgi-plugin.xml" />
+
+	<property name="auto.deploy.dir" value="${liferay.home}/osgi/portal" />
+</project>

--- a/modules/portal/portal-cache/ivy.xml
+++ b/modules/portal/portal-cache/ivy.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+
+<ivy-module
+	version="2.0"
+	xmlns:m2="http://ant.apache.org/ivy/maven"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd"
+>
+	<info module="${plugin.name}" organisation="com.liferay">
+		<extends extendType="configurations,description,info" location="${sdk.dir}/ivy.xml" module="com.liferay.sdk" organisation="com.liferay" revision="latest.integration" />
+	</info>
+
+	<publications>
+		<artifact type="jar" />
+		<artifact type="pom" />
+		<artifact m2:classifier="sources" />
+	</publications>
+
+	<dependencies defaultconf="default">
+		<dependency name="org.osgi.compendium" org="org.osgi" rev="5.0.0" />
+		<dependency name="org.osgi.core" org="org.osgi" rev="5.0.0" />
+	</dependencies>
+</ivy-module>

--- a/modules/portal/portal-cache/src/com/liferay/portal/cache/internal/MultiVMPoolImpl.java
+++ b/modules/portal/portal-cache/src/com/liferay/portal/cache/internal/MultiVMPoolImpl.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.cache;
+package com.liferay.portal.cache.internal;
 
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;

--- a/modules/portal/portal-cache/src/com/liferay/portal/cache/internal/SingleVMPoolImpl.java
+++ b/modules/portal/portal-cache/src/com/liferay/portal/cache/internal/SingleVMPoolImpl.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.cache;
+package com.liferay.portal.cache.internal;
 
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheManager;

--- a/modules/portal/portal-template-freemarker/src/com/liferay/portal/template/freemarker/FreeMarkerTemplateResourceLoader.java
+++ b/modules/portal/portal-template-freemarker/src/com/liferay/portal/template/freemarker/FreeMarkerTemplateResourceLoader.java
@@ -16,8 +16,8 @@ package com.liferay.portal.template.freemarker;
 
 import aQute.bnd.annotation.metatype.Configurable;
 
-import com.liferay.portal.kernel.cache.MultiVMPoolUtil;
-import com.liferay.portal.kernel.cache.SingleVMPoolUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.SingleVMPool;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateResource;
 import com.liferay.portal.kernel.template.TemplateResourceLoader;
@@ -88,11 +88,11 @@ public class FreeMarkerTemplateResourceLoader
 	}
 
 	@Reference(unbind = "-")
-	protected void setMultiVMPoolUtil(MultiVMPoolUtil multiVMPoolUtil) {
+	protected void setMultiVMPool(MultiVMPool multiVMPool) {
 	}
 
 	@Reference(unbind = "-")
-	protected void setSingleVMPoolUtil(SingleVMPoolUtil singleVMPoolUtil) {
+	protected void setSingleVMPool(SingleVMPool singleVMPool) {
 	}
 
 	private static volatile DefaultTemplateResourceLoader

--- a/modules/portal/portal-template-velocity/src/com/liferay/portal/template/velocity/VelocityTemplateResourceLoader.java
+++ b/modules/portal/portal-template-velocity/src/com/liferay/portal/template/velocity/VelocityTemplateResourceLoader.java
@@ -16,8 +16,8 @@ package com.liferay.portal.template.velocity;
 
 import aQute.bnd.annotation.metatype.Configurable;
 
-import com.liferay.portal.kernel.cache.MultiVMPoolUtil;
-import com.liferay.portal.kernel.cache.SingleVMPoolUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.SingleVMPool;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateResource;
 import com.liferay.portal.kernel.template.TemplateResourceLoader;
@@ -88,11 +88,11 @@ public class VelocityTemplateResourceLoader implements TemplateResourceLoader {
 	}
 
 	@Reference(unbind = "-")
-	protected void setMultiVMPoolUtil(MultiVMPoolUtil multiVMPoolUtil) {
+	protected void setMultiVMPool(MultiVMPool multiVMPool) {
 	}
 
 	@Reference(unbind = "-")
-	protected void setSingleVMPoolUtil(SingleVMPoolUtil singleVMPoolUtil) {
+	protected void setSingleVMPool(SingleVMPool singleVMPool) {
 	}
 
 	private static volatile DefaultTemplateResourceLoader

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -41,6 +41,10 @@
 			<bean class="com.liferay.portal.bean.ConstantsBeanFactoryImpl" />
 		</property>
 	</bean>
+	<bean id="com.liferay.portal.kernel.resiliency.spi.cache.SPIPortalCacheManagerConfigurator" class="com.liferay.portal.resiliency.spi.cache.SPIPortalCacheManagerConfiguratorImpl" />
+	<bean id="com.liferay.portal.kernel.resiliency.spi.cache.SPIPortalCacheManagerConfiguratorUtil" class="com.liferay.portal.kernel.resiliency.spi.cache.SPIPortalCacheManagerConfiguratorUtil">
+		<property name="sPIPortalCacheManagerConfigurator" ref="com.liferay.portal.kernel.resiliency.spi.cache.SPIPortalCacheManagerConfigurator" />
+	</bean>
 	<bean id="com.liferay.portal.kernel.cache.MultiVMPool" class="com.liferay.portal.cache.MultiVMPoolImpl" />
 	<bean id="com.liferay.portal.kernel.cache.MultiVMPoolUtil" class="com.liferay.portal.kernel.cache.MultiVMPoolUtil">
 		<property name="multiVMPool" ref="com.liferay.portal.kernel.cache.MultiVMPool" />

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -45,14 +45,6 @@
 	<bean id="com.liferay.portal.kernel.resiliency.spi.cache.SPIPortalCacheManagerConfiguratorUtil" class="com.liferay.portal.kernel.resiliency.spi.cache.SPIPortalCacheManagerConfiguratorUtil">
 		<property name="sPIPortalCacheManagerConfigurator" ref="com.liferay.portal.kernel.resiliency.spi.cache.SPIPortalCacheManagerConfigurator" />
 	</bean>
-	<bean id="com.liferay.portal.kernel.cache.MultiVMPool" class="com.liferay.portal.cache.MultiVMPoolImpl" />
-	<bean id="com.liferay.portal.kernel.cache.MultiVMPoolUtil" class="com.liferay.portal.kernel.cache.MultiVMPoolUtil">
-		<property name="multiVMPool" ref="com.liferay.portal.kernel.cache.MultiVMPool" />
-	</bean>
-	<bean id="com.liferay.portal.kernel.cache.SingleVMPool" class="com.liferay.portal.cache.SingleVMPoolImpl" />
-	<bean id="com.liferay.portal.kernel.cache.SingleVMPoolUtil" class="com.liferay.portal.kernel.cache.SingleVMPoolUtil">
-		<property name="singleVMPool" ref="com.liferay.portal.kernel.cache.SingleVMPool" />
-	</bean>
 	<bean id="com.liferay.portal.kernel.cache.key.CacheKeyGeneratorUtil" class="com.liferay.portal.kernel.cache.key.CacheKeyGeneratorUtil">
 		<property name="cacheKeyGenerators">
 			<map>

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -88,16 +88,12 @@
 	</bean>
 	<bean id="com.liferay.portal.kernel.dao.orm.EntityCacheUtil" class="com.liferay.portal.kernel.dao.orm.EntityCacheUtil">
 		<property name="entityCache">
-			<bean class="com.liferay.portal.dao.orm.common.EntityCacheImpl">
-				<property name="multiVMPool" ref="com.liferay.portal.kernel.cache.MultiVMPool" />
-			</bean>
+			<bean class="com.liferay.portal.dao.orm.common.EntityCacheImpl" />
 		</property>
 	</bean>
 	<bean id="com.liferay.portal.kernel.dao.orm.FinderCacheUtil" class="com.liferay.portal.kernel.dao.orm.FinderCacheUtil">
 		<property name="finderCache">
-			<bean class="com.liferay.portal.dao.orm.common.FinderCacheImpl">
-				<property name="multiVMPool" ref="com.liferay.portal.kernel.cache.MultiVMPool" />
-			</bean>
+			<bean class="com.liferay.portal.dao.orm.common.FinderCacheImpl" />
 		</property>
 	</bean>
 	<bean id="com.liferay.portal.kernel.dao.orm.PortalCustomSQLUtil" class="com.liferay.portal.kernel.dao.orm.PortalCustomSQLUtil">
@@ -412,9 +408,7 @@
 	</bean>
 	<bean id="com.liferay.portal.kernel.webcache.WebCachePoolUtil" class="com.liferay.portal.kernel.webcache.WebCachePoolUtil">
 		<property name="webCachePool">
-			<bean class="com.liferay.portal.webcache.WebCachePoolImpl">
-				<property name="singleVMPool" ref="com.liferay.portal.kernel.cache.SingleVMPool" />
-			</bean>
+			<bean class="com.liferay.portal.webcache.WebCachePoolImpl" />
 		</property>
 	</bean>
 	<bean id="com.liferay.portal.kernel.webdav.methods.MethodFactoryRegistryUtil" class="com.liferay.portal.kernel.webdav.methods.MethodFactoryRegistryUtil">
@@ -795,9 +789,7 @@
 	<bean class="com.liferay.portal.verify.model.WebSiteVerifiableModel" />
 	<bean id="com.liferay.portal.webserver.WebServerServletTokenUtil" class="com.liferay.portal.webserver.WebServerServletTokenUtil">
 		<property name="webServerServletToken">
-			<bean class="com.liferay.portal.webserver.WebServerServletTokenImpl">
-				<property name="multiVMPool" ref="com.liferay.portal.kernel.cache.MultiVMPool" />
-			</bean>
+			<bean class="com.liferay.portal.webserver.WebServerServletTokenImpl" />
 		</property>
 	</bean>
 	<bean id="com.liferay.portal.workflow.LayoutRevisionWorkflowHandler" class="com.liferay.portal.workflow.LayoutRevisionWorkflowHandler" />

--- a/portal-impl/src/com/liferay/portal/cache/MultiVMPoolImpl.java
+++ b/portal-impl/src/com/liferay/portal/cache/MultiVMPoolImpl.java
@@ -18,9 +18,9 @@ import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheManager;
 import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
+import com.liferay.portal.kernel.resiliency.spi.cache.SPIPortalCacheManagerConfiguratorUtil;
 import com.liferay.portal.kernel.security.pacl.DoPrivileged;
 import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.resiliency.spi.cache.SPIPortalCacheManagerConfigurator;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.registry.Filter;
 import com.liferay.registry.Registry;
@@ -64,8 +64,9 @@ public class MultiVMPoolImpl implements MultiVMPool {
 
 		try {
 			_portalCacheManager =
-				SPIPortalCacheManagerConfigurator.createSPIPortalCacheManager(
-					serviceTracker.waitForService(0));
+				SPIPortalCacheManagerConfiguratorUtil.
+					createSPIPortalCacheManager(
+						serviceTracker.waitForService(0));
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(

--- a/portal-impl/src/com/liferay/portal/resiliency/spi/cache/SPIPortalCacheManagerConfiguratorImpl.java
+++ b/portal-impl/src/com/liferay/portal/resiliency/spi/cache/SPIPortalCacheManagerConfiguratorImpl.java
@@ -27,6 +27,9 @@ import com.liferay.portal.nio.intraband.cache.BaseIntrabandPortalCacheManager;
 import com.liferay.portal.nio.intraband.proxy.IntrabandProxyInstallationUtil;
 import com.liferay.portal.nio.intraband.proxy.IntrabandProxyUtil;
 import com.liferay.portal.nio.intraband.proxy.WarnLogExceptionHandler;
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+import com.liferay.registry.ServiceRegistration;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -39,6 +42,13 @@ import java.util.concurrent.Future;
  */
 public class SPIPortalCacheManagerConfiguratorImpl
 	implements SPIPortalCacheManagerConfigurator {
+
+	public void afterPropertiesSet() {
+		Registry registry = RegistryUtil.getRegistry();
+
+		_serviceRegistration = registry.registerService(
+			SPIPortalCacheManagerConfigurator.class, this);
+	}
 
 	@Override
 	public PortalCacheManager<? extends Serializable, ? extends Serializable>
@@ -98,6 +108,15 @@ public class SPIPortalCacheManagerConfiguratorImpl
 			stubClass, StringPool.BLANK, registrationReference,
 			WarnLogExceptionHandler.INSTANCE);
 	}
+
+	public void destroy() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	private ServiceRegistration<SPIPortalCacheManagerConfigurator>
+		_serviceRegistration;
 
 	private static class IntrabandPortalCacheTargetLocator
 		implements TargetLocator {

--- a/portal-impl/src/com/liferay/portal/resiliency/spi/cache/SPIPortalCacheManagerConfiguratorImpl.java
+++ b/portal-impl/src/com/liferay/portal/resiliency/spi/cache/SPIPortalCacheManagerConfiguratorImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.nio.intraband.RegistrationReference;
 import com.liferay.portal.kernel.nio.intraband.proxy.TargetLocator;
 import com.liferay.portal.kernel.resiliency.spi.SPI;
 import com.liferay.portal.kernel.resiliency.spi.SPIUtil;
+import com.liferay.portal.kernel.resiliency.spi.cache.SPIPortalCacheManagerConfigurator;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.nio.intraband.cache.BaseIntrabandPortalCacheManager;
 import com.liferay.portal.nio.intraband.proxy.IntrabandProxyInstallationUtil;
@@ -36,11 +37,15 @@ import java.util.concurrent.Future;
 /**
  * @author Shuyang Zhou
  */
-public class SPIPortalCacheManagerConfigurator {
+public class SPIPortalCacheManagerConfiguratorImpl
+	implements SPIPortalCacheManagerConfigurator {
 
-	public static <K extends Serializable, V extends Serializable>
-		PortalCacheManager<K, V> createSPIPortalCacheManager(
-			PortalCacheManager<K, V> portalCacheManager)
+	@Override
+	public PortalCacheManager<? extends Serializable, ? extends Serializable>
+		createSPIPortalCacheManager(
+			PortalCacheManager
+				<? extends Serializable, ? extends Serializable>
+					portalCacheManager)
 		throws Exception {
 
 		if (!SPIUtil.isSPI()) {
@@ -74,11 +79,14 @@ public class SPIPortalCacheManagerConfigurator {
 
 		skeletonProxyMethodSignatures = future.get();
 
-		Class<? extends PortalCacheManager<K, V>> stubClass =
-			(Class<? extends PortalCacheManager<K, V>>)
-				IntrabandProxyUtil.getStubClass(
-					BaseIntrabandPortalCacheManager.class,
-					PortalCacheManager.class.getName());
+		Class<? extends PortalCacheManager
+			<? extends Serializable, ? extends Serializable>>
+				stubClass =
+					(Class<? extends PortalCacheManager
+						<? extends Serializable, ? extends Serializable>>)
+					IntrabandProxyUtil.getStubClass(
+						BaseIntrabandPortalCacheManager.class,
+						PortalCacheManager.class.getName());
 
 		stubProxyMethodSignatures = IntrabandProxyUtil.getProxyMethodSignatures(
 			stubClass);
@@ -86,11 +94,9 @@ public class SPIPortalCacheManagerConfigurator {
 		IntrabandProxyInstallationUtil.checkProxyMethodSignatures(
 			skeletonProxyMethodSignatures, stubProxyMethodSignatures);
 
-		portalCacheManager = IntrabandProxyUtil.newStubInstance(
+		return IntrabandProxyUtil.newStubInstance(
 			stubClass, StringPool.BLANK, registrationReference,
 			WarnLogExceptionHandler.INSTANCE);
-
-		return portalCacheManager;
 	}
 
 	private static class IntrabandPortalCacheTargetLocator

--- a/portal-impl/src/com/liferay/portal/tools/ToolDependencies.java
+++ b/portal-impl/src/com/liferay/portal/tools/ToolDependencies.java
@@ -15,14 +15,13 @@
 package com.liferay.portal.tools;
 
 import com.liferay.portal.cache.DummyPortalCacheManager;
-import com.liferay.portal.cache.MultiVMPoolImpl;
-import com.liferay.portal.cache.SingleVMPoolImpl;
 import com.liferay.portal.cache.key.SimpleCacheKeyGenerator;
 import com.liferay.portal.json.JSONFactoryImpl;
-import com.liferay.portal.kernel.cache.MultiVMPoolUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheManager;
 import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
-import com.liferay.portal.kernel.cache.SingleVMPoolUtil;
+import com.liferay.portal.kernel.cache.SingleVMPool;
 import com.liferay.portal.kernel.cache.key.CacheKeyGeneratorUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.microsofttranslator.MicrosoftTranslatorFactoryUtil;
@@ -54,14 +53,12 @@ import com.liferay.portal.util.HttpImpl;
 import com.liferay.portal.util.InitUtil;
 import com.liferay.portal.util.PortalImpl;
 import com.liferay.portal.util.PortalUtil;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.xml.SAXReaderImpl;
 import com.liferay.registry.BasicRegistryImpl;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.Serializable;
 
 /**
  * @author Raymond Augé
@@ -165,39 +162,17 @@ public class ToolDependencies {
 
 		Registry registry = RegistryUtil.getRegistry();
 
-		Map<String, Object> properties = new HashMap<>();
-
-		properties.put(
-			"portal.cache.manager.name", PortalCacheManagerNames.SINGLE_VM);
-		properties.put(
-			"portal.cache.manager.type",
-			PropsValues.PORTAL_CACHE_MANAGER_TYPE_SINGLE_VM);
+		registry.registerService(
+			SingleVMPool.class,
+			new TestSingleVMPool(
+				new DummyPortalCacheManager<>(
+					PortalCacheManagerNames.SINGLE_VM)));
 
 		registry.registerService(
-			PortalCacheManager.class,
-			new DummyPortalCacheManager<>(PortalCacheManagerNames.SINGLE_VM),
-			properties);
-
-		SingleVMPoolUtil singleVMPoolUtil = new SingleVMPoolUtil();
-
-		singleVMPoolUtil.setSingleVMPool(new SingleVMPoolImpl());
-
-		properties = new HashMap<>();
-
-		properties.put(
-			"portal.cache.manager.name", PortalCacheManagerNames.MULTI_VM);
-		properties.put(
-			"portal.cache.manager.type",
-			PropsValues.PORTAL_CACHE_MANAGER_TYPE_MULTI_VM);
-
-		registry.registerService(
-			PortalCacheManager.class,
-			new DummyPortalCacheManager<>(PortalCacheManagerNames.MULTI_VM),
-			properties);
-
-		MultiVMPoolUtil multiVMPoolUtil = new MultiVMPoolUtil();
-
-		multiVMPoolUtil.setMultiVMPool(new MultiVMPoolImpl());
+			MultiVMPool.class,
+			new TestMultiVMPool(
+				new DummyPortalCacheManager<>(
+					PortalCacheManagerNames.MULTI_VM)));
 	}
 
 	public static void wireDeployers() {
@@ -218,6 +193,98 @@ public class ToolDependencies {
 		resourceActionsImpl.afterPropertiesSet();
 
 		resourceActionsUtil.setResourceActions(resourceActionsImpl);
+	}
+
+	private static class TestMultiVMPool implements MultiVMPool {
+
+		public TestMultiVMPool(
+			PortalCacheManager<? extends Serializable, ?>
+				portalCacheManager) {
+
+			_portalCacheManager =
+				(PortalCacheManager
+					<? extends Serializable, ? extends Serializable>)
+				portalCacheManager;
+		}
+
+		@Override
+		public void clear() {
+			_portalCacheManager.clearAll();
+		}
+
+		@Override
+		public PortalCache<? extends Serializable, ? extends Serializable>
+			getCache(String portalCacheName) {
+
+			return _portalCacheManager.getCache(portalCacheName);
+		}
+
+		@Override
+		public PortalCache<? extends Serializable, ? extends Serializable>
+			getCache(String portalCacheName, boolean blocking) {
+
+			return _portalCacheManager.getCache(portalCacheName, blocking);
+		}
+
+		@Override
+		public PortalCacheManager
+			<? extends Serializable, ? extends Serializable>
+				getCacheManager() {
+
+			return _portalCacheManager;
+		}
+
+		@Override
+		public void removeCache(String portalCacheName) {
+			_portalCacheManager.removeCache(portalCacheName);
+		}
+
+		private final PortalCacheManager
+			<? extends Serializable, ? extends Serializable>
+				_portalCacheManager;
+
+	}
+
+	private static class TestSingleVMPool implements SingleVMPool {
+
+		public TestSingleVMPool(
+			PortalCacheManager<? extends Serializable, ?> portalCacheManager) {
+
+			_portalCacheManager = portalCacheManager;
+		}
+
+		@Override
+		public void clear() {
+			_portalCacheManager.clearAll();
+		}
+
+		@Override
+		public PortalCache<? extends Serializable, ?> getCache(
+			String portalCacheName) {
+
+			return _portalCacheManager.getCache(portalCacheName);
+		}
+
+		@Override
+		public PortalCache<? extends Serializable, ?> getCache(
+			String portalCacheName, boolean blocking) {
+
+			return _portalCacheManager.getCache(portalCacheName, blocking);
+		}
+
+		@Override
+		public PortalCacheManager<? extends Serializable, ?> getCacheManager() {
+			return _portalCacheManager;
+		}
+
+		@Override
+		public void removeCache(String portalCacheName) {
+			_portalCacheManager.removeCache(portalCacheName);
+		}
+
+		private final PortalCacheManager<? extends Serializable, ?>
+			_portalCacheManager;
+
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/webcache/WebCachePoolImpl.java
+++ b/portal-impl/src/com/liferay/portal/webcache/WebCachePoolImpl.java
@@ -15,7 +15,7 @@
 package com.liferay.portal.webcache;
 
 import com.liferay.portal.kernel.cache.PortalCache;
-import com.liferay.portal.kernel.cache.SingleVMPool;
+import com.liferay.portal.kernel.cache.SingleVMPoolUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.pacl.DoPrivileged;
@@ -31,8 +31,7 @@ import com.liferay.portal.kernel.webcache.WebCachePool;
 public class WebCachePoolImpl implements WebCachePool {
 
 	public void afterPropertiesSet() {
-		_portalCache = (PortalCache<String, Object>)_singleVMPool.getCache(
-			_CACHE_NAME);
+		_portalCache = SingleVMPoolUtil.getCache(_CACHE_NAME);
 	}
 
 	@Override
@@ -76,16 +75,11 @@ public class WebCachePoolImpl implements WebCachePool {
 		_portalCache.remove(key);
 	}
 
-	public void setSingleVMPool(SingleVMPool singleVMPool) {
-		_singleVMPool = singleVMPool;
-	}
-
 	private static final String _CACHE_NAME = WebCachePool.class.getName();
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		WebCachePoolImpl.class);
 
 	private PortalCache<String, Object> _portalCache;
-	private SingleVMPool _singleVMPool;
 
 }

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServletTokenImpl.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServletTokenImpl.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.webserver;
 
-import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.MultiVMPoolUtil;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.security.pacl.DoPrivileged;
 import com.liferay.portal.servlet.filters.cache.CacheUtil;
@@ -27,8 +27,7 @@ import com.liferay.portal.servlet.filters.cache.CacheUtil;
 public class WebServerServletTokenImpl implements WebServerServletToken {
 
 	public void afterPropertiesSet() {
-		_portalCache = (PortalCache<Long, String>)_multiVMPool.getCache(
-			_CACHE_NAME);
+		_portalCache = MultiVMPoolUtil.getCache(_CACHE_NAME);
 	}
 
 	@Override
@@ -55,10 +54,6 @@ public class WebServerServletTokenImpl implements WebServerServletToken {
 		CacheUtil.clearCache();
 	}
 
-	public void setMultiVMPool(MultiVMPool multiVMPool) {
-		_multiVMPool = multiVMPool;
-	}
-
 	private String _createToken() {
 		return String.valueOf(System.currentTimeMillis());
 	}
@@ -66,7 +61,6 @@ public class WebServerServletTokenImpl implements WebServerServletToken {
 	private static final String _CACHE_NAME =
 		WebServerServletToken.class.getName();
 
-	private MultiVMPool _multiVMPool;
 	private PortalCache<Long, String> _portalCache;
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/service/persistence/impl/TableMapperTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/service/persistence/impl/TableMapperTest.java
@@ -39,6 +39,10 @@ import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.model.BaseModelListener;
 import com.liferay.portal.model.ModelListener;
 import com.liferay.portal.util.PropsImpl;
+import com.liferay.registry.BasicRegistryImpl;
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+import com.liferay.registry.ServiceRegistration;
 
 import java.io.Serializable;
 
@@ -57,8 +61,10 @@ import java.util.Set;
 
 import javax.sql.DataSource;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -82,6 +88,11 @@ public class TableMapperTest {
 
 		};
 
+	@BeforeClass
+	public static void setUpClass() {
+		RegistryUtil.setRegistry(new BasicRegistryImpl());
+	}
+
 	@Before
 	public void setUp() {
 		MappingSqlQueryFactoryUtil mappingSqlQueryFactoryUtil =
@@ -90,9 +101,10 @@ public class TableMapperTest {
 		mappingSqlQueryFactoryUtil.setMappingSqlQueryFactory(
 			new MockMappingSqlQueryFactory());
 
-		MultiVMPoolUtil multiVMPoolUtil = new MultiVMPoolUtil();
+		Registry registry = RegistryUtil.getRegistry();
 
-		multiVMPoolUtil.setMultiVMPool(new MockMultiVMPool());
+		_serviceRegistration = registry.registerService(
+			MultiVMPool.class, new MockMultiVMPool());
 
 		PropsUtil.setProps(new PropsImpl());
 
@@ -128,6 +140,11 @@ public class TableMapperTest {
 		_tableMapperImpl = new TableMapperImpl<Left, Right>(
 			_TABLE_NAME, _LEFT_COLUMN_NAME, _RIGHT_COLUMN_NAME,
 			_leftBasePersistence, _rightBasePersistence);
+	}
+
+	@After
+	public void tearDown() {
+		_serviceRegistration.unregister();
 	}
 
 	@Test
@@ -1396,6 +1413,7 @@ public class TableMapperTest {
 	private MockBasePersistence<Left> _leftBasePersistence;
 	private final Map<Long, long[]> _mappingStore = new HashMap<>();
 	private MockBasePersistence<Right> _rightBasePersistence;
+	private ServiceRegistration<MultiVMPool> _serviceRegistration;
 	private TableMapperImpl<Left, Right> _tableMapperImpl;
 
 	private class GetPrimaryKeyObjInvocationHandler

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/spi/cache/SPIPortalCacheManagerConfigurator.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/spi/cache/SPIPortalCacheManagerConfigurator.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.resiliency.spi.cache;
+
+import com.liferay.portal.kernel.cache.PortalCacheManager;
+
+import java.io.Serializable;
+
+/**
+ * @author Tina Tian
+ */
+public interface SPIPortalCacheManagerConfigurator {
+
+	public PortalCacheManager<? extends Serializable, ? extends Serializable>
+		createSPIPortalCacheManager(
+			PortalCacheManager
+				<? extends Serializable, ? extends Serializable>
+					portalCacheManager)
+		throws Exception;
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/spi/cache/SPIPortalCacheManagerConfiguratorUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/spi/cache/SPIPortalCacheManagerConfiguratorUtil.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.resiliency.spi.cache;
+
+import com.liferay.portal.kernel.cache.PortalCacheManager;
+
+import java.io.Serializable;
+
+/**
+ * @author Tina Tian
+ */
+public class SPIPortalCacheManagerConfiguratorUtil {
+
+	public static <K extends Serializable, V extends Serializable>
+		PortalCacheManager<K, V> createSPIPortalCacheManager(
+			PortalCacheManager<K, V> portalCacheManager)
+		throws Exception {
+
+		return (PortalCacheManager<K, V>)
+			_spiPortalCacheManagerConfigurator.createSPIPortalCacheManager(
+				portalCacheManager);
+	}
+
+	public void setSPIPortalCacheManagerConfigurator(
+		SPIPortalCacheManagerConfigurator spiPortalCacheManagerConfigurator) {
+
+		_spiPortalCacheManagerConfigurator = spiPortalCacheManagerConfigurator;
+	}
+
+	private static SPIPortalCacheManagerConfigurator
+		_spiPortalCacheManagerConfigurator;
+
+}

--- a/portal-test-internal/src/com/liferay/portal/scripting/ScriptingExecutorTestCase.java
+++ b/portal-test-internal/src/com/liferay/portal/scripting/ScriptingExecutorTestCase.java
@@ -14,35 +14,31 @@
 
 package com.liferay.portal.scripting;
 
-import com.liferay.portal.kernel.cache.PortalCache;
-import com.liferay.portal.kernel.cache.SingleVMPoolUtil;
 import com.liferay.portal.kernel.scripting.ScriptingExecutor;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.tools.ToolDependencies;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
-
-import org.mockito.Mock;
-import org.mockito.Mockito;
-
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 /**
  * @author Miguel Pastor
  */
-@PrepareForTest(SingleVMPoolUtil.class)
-public abstract class ScriptingExecutorTestCase extends PowerMockito {
+public abstract class ScriptingExecutorTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		ToolDependencies.wireCaches();
+	}
 
 	public abstract String getScriptExtension();
 
@@ -50,20 +46,7 @@ public abstract class ScriptingExecutorTestCase extends PowerMockito {
 
 	@Before
 	public void setUp() {
-		mockStatic(SingleVMPoolUtil.class);
-
-		when(
-			SingleVMPoolUtil.getCache(Mockito.anyString())
-		).thenReturn(
-			_portalCache
-		);
-
 		_scriptingExecutor = getScriptingExecutor();
-	}
-
-	@After
-	public void tearDown() {
-		verifyStatic();
 	}
 
 	@Test
@@ -103,9 +86,6 @@ public abstract class ScriptingExecutorTestCase extends PowerMockito {
 
 		return StringUtil.read(inputStream);
 	}
-
-	@Mock
-	private PortalCache<Serializable, Object> _portalCache;
 
 	private ScriptingExecutor _scriptingExecutor;
 


### PR DESCRIPTION
Hi Micheal,

In the last commit of this pull request, I exported spring bean manually since MultiVMPool depends on it and other spring beans depend on MultiVMPool.  

The side effect is we would have same instance registered twice, I can add an annotation to skip the automatic export, however, considering it can be fixed automatically after we move SPI things out, I would like to hold it back now.


Tina.
