### PR TITLE
Lps 55712 Merge FriendlyURL logic

### DIFF
--- a/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/servlet/filters/MonitoringFilter.java
+++ b/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/servlet/filters/MonitoringFilter.java
@@ -27,10 +27,18 @@ import com.liferay.portal.kernel.monitoring.PortletMonitoringControl;
 import com.liferay.portal.kernel.monitoring.RequestStatus;
 import com.liferay.portal.kernel.monitoring.ServiceMonitoringControl;
 import com.liferay.portal.kernel.servlet.BaseFilter;
+import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.User;
+import com.liferay.portal.service.GroupLocalService;
 import com.liferay.portal.service.LayoutLocalService;
+import com.liferay.portal.service.UserLocalService;
+import com.liferay.portal.util.Portal;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PortalUtil;
 
 import java.io.IOException;
@@ -92,6 +100,23 @@ public class MonitoringFilter extends BaseFilter
 		_monitorPortalRequest = monitorPortalRequest;
 	}
 
+	protected Object[] getFriendlyURLPathInfo(String requestURI) {
+		if (requestURI.startsWith(PortalUtil.getPathFriendlyURLPrivateUser())) {
+			return new Object[] {
+				PortalUtil.getPathFriendlyURLPrivateUser(), true
+			};
+		}
+		else if (requestURI.startsWith(
+					PortalUtil.getPathFriendlyURLPrivateGroup())) {
+
+			return new Object[] {
+				PortalUtil.getPathFriendlyURLPrivateGroup(), false
+			};
+		}
+
+		return new Object[] {PortalUtil.getPathFriendlyURLPublic(), false};
+	}
+
 	protected long getGroupId(HttpServletRequest request) {
 		long groupId = ParamUtil.getLong(request, "groupId");
 
@@ -114,12 +139,118 @@ public class MonitoringFilter extends BaseFilter
 			}
 		}
 
+		if (groupId > 0) {
+			return groupId;
+		}
+		else {
+			try {
+				groupId = getGroupIdFromPath(request);
+			}
+			catch (Exception e) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Unable to retrieve groupId from request URI", e);
+				}
+			}
+		}
+
 		return groupId;
+	}
+
+	protected long getGroupIdFromPath(HttpServletRequest request) {
+		Object[] pathInfo = getPathInfo(request);
+		String path = (String)pathInfo[0];
+		boolean isUser = (boolean)pathInfo[1];
+
+		String friendlyURL = null;
+
+		int pos = path.indexOf(CharPool.SLASH, 1);
+
+		if (pos != -1) {
+			friendlyURL = path.substring(0, pos);
+		}
+		else if (path.length() > 1) {
+			friendlyURL = path;
+		}
+
+		if (Validator.isNull(friendlyURL)) {
+			return 0;
+		}
+
+		long companyId = PortalInstances.getCompanyId(request);
+
+		Group group = _groupLocalService.fetchFriendlyURLGroup(
+			companyId, friendlyURL);
+
+		if (group == null) {
+			String screenName = friendlyURL.substring(1);
+
+			if (isUser || !Validator.isNumber(screenName)) {
+				User user = _userLocalService.fetchUserByScreenName(
+					companyId, screenName);
+
+				if (user != null) {
+					group = user.getGroup();
+				}
+				else if (_log.isWarnEnabled()) {
+					_log.warn("No user exists with friendly URL " + screenName);
+				}
+			}
+			else {
+				long groupId = GetterUtil.getLong(screenName);
+
+				group = _groupLocalService.fetchGroup(groupId);
+
+				if (group == null) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"No group exists with friendly URL " + groupId +
+								". Try fetching by screen name instead.");
+					}
+
+					User user = _userLocalService.fetchUserByScreenName(
+						companyId, screenName);
+
+					if (user != null) {
+						group = user.getGroup();
+					}
+					else if (_log.isWarnEnabled()) {
+						_log.warn(
+							"No user or group exists with friendly URL " +
+								groupId);
+					}
+				}
+			}
+		}
+
+		if (group == null) {
+			return 0;
+		}
+
+		return group.getGroupId();
 	}
 
 	@Override
 	protected Log getLog() {
 		return _log;
+	}
+
+	protected Object[] getPathInfo(HttpServletRequest request) {
+		String requestURI = request.getRequestURI();
+		Object[] friendlyURLPathInfo = getFriendlyURLPathInfo(requestURI);
+		String friendlyURLPathPrefix = (String)friendlyURLPathInfo[0];
+		Boolean isUser = (Boolean)friendlyURLPathInfo[1];
+
+		int pos = requestURI.indexOf(Portal.JSESSIONID);
+
+		if (pos != -1) {
+			requestURI = requestURI.substring(0, pos);
+		}
+
+		String pathProxy = PortalUtil.getPathProxy();
+
+		pos = friendlyURLPathPrefix.length() - pathProxy.length();
+
+		return new Object[] {requestURI.substring(pos), isUser};
 	}
 
 	@Override
@@ -190,6 +321,15 @@ public class MonitoringFilter extends BaseFilter
 		policy = ReferencePolicy.DYNAMIC,
 		policyOption = ReferencePolicyOption.GREEDY
 	)
+	protected void setGroupLocalService(GroupLocalService groupLocalService) {
+		_groupLocalService = groupLocalService;
+	}
+
+	@Reference(
+		cardinality = ReferenceCardinality.OPTIONAL,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
 	protected void setLayoutLocalService(
 		LayoutLocalService layoutLocalService) {
 
@@ -210,19 +350,38 @@ public class MonitoringFilter extends BaseFilter
 		_serviceMonitoringControl = serviceMonitoringControl;
 	}
 
+	@Reference(
+		cardinality = ReferenceCardinality.OPTIONAL,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected void setUserLocalService(UserLocalService userLocalService) {
+		_userLocalService = userLocalService;
+	}
+
+	protected void unsetGroupLocalService(GroupLocalService groupLocalService) {
+		_groupLocalService = null;
+	}
+
 	protected void unsetLayoutLocalService(
 		LayoutLocalService layoutLocalService) {
 
 		_layoutLocalService = null;
 	}
 
+	protected void unsetUserLocalService(UserLocalService userLocalService) {
+		_userLocalService = null;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		MonitoringFilter.class);
 
 	private DataSampleFactory _dataSampleFactory;
+	private volatile GroupLocalService _groupLocalService;
 	private volatile LayoutLocalService _layoutLocalService;
 	private boolean _monitorPortalRequest;
 	private PortletMonitoringControl _portletMonitoringControl;
 	private ServiceMonitoringControl _serviceMonitoringControl;
+	private volatile UserLocalService _userLocalService;
 
 }

--- a/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/servlet/filters/MonitoringFilter.java
+++ b/modules/portal/portal-monitoring/src/com/liferay/portal/monitoring/internal/servlet/filters/MonitoringFilter.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.User;
@@ -225,6 +226,8 @@ public class MonitoringFilter extends BaseFilter
 		if (group == null) {
 			return 0;
 		}
+
+		request.setAttribute(WebKeys.FRIENDLY_URL_GROUP, group);
 
 		return group.getGroupId();
 	}

--- a/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
@@ -224,8 +224,12 @@ public class FriendlyURLServlet extends HttpServlet {
 
 		long companyId = PortalInstances.getCompanyId(request);
 
-		Group group = GroupLocalServiceUtil.fetchFriendlyURLGroup(
-			companyId, friendlyURL);
+		Group group = (Group) request.getAttribute(WebKeys.FRIENDLY_URL_GROUP);
+
+		if (group == null) {
+			group = GroupLocalServiceUtil.fetchFriendlyURLGroup(
+				companyId, friendlyURL);
+		}
 
 		if (group == null) {
 			String screenName = friendlyURL.substring(1);

--- a/portal-service/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -76,6 +76,8 @@ public interface WebKeys {
 
 	public static final String FORGOT_PASSWORD_REMINDER_USER_EMAIL_ADDRESS = "FORGOT_PASSWORD_REMINDER_USER_EMAIL_ADDRESS";
 
+	public static final String FRIENDLY_URL_GROUP = "FRIENDLY_URL_GROUP";
+
 	public static final String GROUP = "GROUP";
 
 	public static final String INVOKER_FILTER_URI = "INVOKER_FILTER_URI";


### PR DESCRIPTION
The first commit re-use the FriendlyURLServlet logic to fetch group info from the friendly url.
The second commit shares the group via request attribute.

There is no obvious place where to share the code (parts of it) between the portal FriendlyURLServlet and the monitoring filter module, I went the way of code-logic duplication.