### PR TITLE
LPS-56971, LPS-56530 on Solr: unit tests documenting regressions and bugs

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngine;
+import com.liferay.portal.kernel.search.SearchEngineUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
@@ -26,6 +28,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -64,6 +67,7 @@ import com.liferay.portlet.dynamicdatamapping.util.test.DDMStructureTestUtil;
 import java.io.File;
 import java.io.InputStream;
 
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -180,6 +184,22 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 	@Override
 	@Test
 	public void testSearchAttachments() throws Exception {
+	}
+
+	@Override
+	@Test
+	public void testSearchByDDMStructureField() throws Exception {
+		Assume.assumeFalse(isTestSkippedOnSolrBrokenByLPS56530());
+
+		super.testSearchByDDMStructureField();
+	}
+
+	@Override
+	@Test
+	public void testSearchStatus() throws Exception {
+		Assume.assumeFalse(isTestSkippedOnSolrBrokenByLPS56530());
+
+		super.testSearchStatus();
 	}
 
 	@Test
@@ -381,9 +401,20 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		return "Title";
 	}
 
+	protected boolean isTestSkippedOnSolrBrokenByLPS56530() {
+		return isSearchEngineVendor("Solr");
+	}
+
 	@Override
 	protected boolean isExpirableAllVersions() {
 		return true;
+	}
+
+	protected boolean isSearchEngineVendor(String... vendors) {
+		SearchEngine searchEngine = SearchEngineUtil.getSearchEngine(
+			SearchEngineUtil.getDefaultSearchEngineId());
+
+		return ArrayUtil.contains(vendors, searchEngine.getVendor(), true);
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
@@ -202,6 +202,14 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		super.testSearchStatus();
 	}
 
+	@Override
+	@Test
+	public void testSearchMixedPhraseKeywords() throws Exception {
+		Assume.assumeFalse(isTestSkippedOnSolrBrokenByLPS56971());
+
+		super.testSearchMixedPhraseKeywords();
+	}
+
 	@Test
 	public void testSearchTikaRawMetadata() throws Exception {
 		ServiceContext serviceContext =
@@ -402,6 +410,10 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 	}
 
 	protected boolean isTestSkippedOnSolrBrokenByLPS56530() {
+		return isSearchEngineVendor("Solr");
+	}
+
+	protected boolean isTestSkippedOnSolrBrokenByLPS56971() {
 		return isSearchEngineVendor("Solr");
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
@@ -281,6 +281,17 @@ public class UserIndexerTest {
 		Assert.assertEquals("open4life", user.getScreenName());
 	}
 
+	@Test
+	public void testScreenNameTwoWords() throws Exception {
+		Assume.assumeFalse(isTestSkippedOnSolrBrokenByLPS56971());
+
+		addUserScreenName("Open4Life");
+
+		User user = assertSearchOneUser("screenName", "open lite");
+
+		Assert.assertEquals("open4life", user.getScreenName());
+	}
+
 	protected User addUser() throws Exception {
 		User user = UserTestUtil.addUser();
 

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
@@ -112,6 +112,8 @@ public class UserIndexerTest {
 
 	@Test
 	public void testEmptyQuery() throws Exception {
+		Assume.assumeFalse(isTestSkippedOnSolrBrokenByLPS56971());
+
 		addUser();
 
 		assertHits("", 1);
@@ -119,6 +121,8 @@ public class UserIndexerTest {
 
 	@Test
 	public void testFirstNameExactPhrase() throws Exception {
+		Assume.assumeFalse(isTestSkippedOnSolrBrokenByLPS56971());
+
 		String firstName = "Mary Jane";
 		String middleName = "Watson";
 		String lastName = "Parker";
@@ -132,6 +136,8 @@ public class UserIndexerTest {
 
 	@Test
 	public void testFirstNameMixedExactPhrase() throws Exception {
+		Assume.assumeFalse(isTestSkippedOnSolrBrokenByLPS56971());
+
 		String firstName = "Mary Jane Watson";
 		String middleName = "Joanne";
 		String lastName = "Parker";
@@ -151,6 +157,8 @@ public class UserIndexerTest {
 
 	@Test
 	public void testLikeCharacter() throws Exception {
+		Assume.assumeFalse(isTestSkippedOnSolrBrokenByLPS56971());
+
 		addUser();
 
 		assertHits("%", 1);
@@ -159,6 +167,8 @@ public class UserIndexerTest {
 
 	@Test
 	public void testLuceneQueryParserUnfriendlyCharacters() throws Exception {
+		Assume.assumeFalse(isTestSkippedOnSolrBrokenByLPS56971());
+
 		User user1 = addUser();
 		User user2 = assertSearchOneUser("@");
 
@@ -406,6 +416,10 @@ public class UserIndexerTest {
 			SearchEngineUtil.getDefaultSearchEngineId());
 
 		return ArrayUtil.contains(vendors, searchEngine.getVendor(), true);
+	}
+
+	protected boolean isTestSkippedOnSolrBrokenByLPS56971() {
+		return isSearchEngineVendor("Solr");
 	}
 
 	protected boolean isTwoEndedSubstringSearchImplementedForSearchEngine() {


### PR DESCRIPTION
The 3 first commits are supposed to be discarded. They're there just to signal which tests went red on Solr because of LPS-56971 and LPS-56530. The original tests should go green after fixes.

However, the last commit ("wildcard support on two words") is a new test documenting a valid query and its expected result. Should we choose to fix this, we should keep the test.