### PR TITLE
LPS-59164 - Support for multiple default Service Access Policies

### DIFF
--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/configuration/SAPConfiguration.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/configuration/SAPConfiguration.java
@@ -26,27 +26,32 @@ import aQute.bnd.annotation.metatype.Meta;
 public interface SAPConfiguration {
 
 	@Meta.AD(
-		deflt = "Default Service Access Policy for Applications",
+		deflt = "System Service Access Policy Applied on Every Request",
 		required = false
 	)
-	public String defaultApplicationSAPEntryDescription();
+	public String systemDefaultSAPEntryDescription();
 
-	@Meta.AD(deflt = "DEFAULT_APP", required = false)
-	public String defaultApplicationSAPEntryName();
+	@Meta.AD(deflt = "SYSTEM_DEFAULT", required = false)
+	public String systemDefaultSAPEntryName();
 
 	@Meta.AD(deflt = "", required = false)
-	public String defaultApplicationSAPEntryServiceSignatures();
+	public String systemDefaultSAPEntryServiceSignatures();
 
-	@Meta.AD(deflt = "Default Service Access Policy for User", required = false)
-	public String defaultUserSAPEntryDescription();
+	@Meta.AD(
+		deflt =
+			"System Service Access Policy for Requests Authenticated " +
+			"using User Password",
+		required = false
+	)
+	public String systemUserPasswordSAPEntryDescription();
 
-	@Meta.AD(deflt = "DEFAULT_USER", required = false)
-	public String defaultUserSAPEntryName();
+	@Meta.AD(deflt = "SYSTEM_USER_PASSWORD", required = false)
+	public String systemUserPasswordSAPEntryName();
 
 	@Meta.AD(deflt = "*", required = false)
-	public String defaultUserSAPEntryServiceSignatures();
+	public String systemUserPasswordSAPEntryServiceSignatures();
 
 	@Meta.AD(deflt = "true", required = false)
-	public boolean requireDefaultSAPEntry();
+	public boolean useSystemSAPEntries();
 
 }

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/model/SAPEntry.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/model/SAPEntry.java
@@ -53,4 +53,7 @@ public interface SAPEntry extends SAPEntryModel, PersistedModel {
 		};
 
 	public java.util.List<java.lang.String> getAllowedServiceSignaturesList();
+
+	public boolean isSystem()
+		throws com.liferay.portal.kernel.module.configuration.ConfigurationException;
 }

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/model/SAPEntryWrapper.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/model/SAPEntryWrapper.java
@@ -428,6 +428,12 @@ public class SAPEntryWrapper implements SAPEntry, ModelWrapper<SAPEntry> {
 	}
 
 	@Override
+	public boolean isSystem()
+		throws com.liferay.portal.kernel.module.configuration.ConfigurationException {
+		return _sapEntry.isSystem();
+	}
+
+	@Override
 	public void persist() {
 		_sapEntry.persist();
 	}

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalService.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalService.java
@@ -65,7 +65,7 @@ public interface SAPEntryLocalService extends BaseLocalService,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws PortalException;
 
-	public void checkDefaultSAPEntry(long companyId) throws PortalException;
+	public void checkSystemSAPEntries(long companyId) throws PortalException;
 
 	/**
 	* Creates a new s a p entry with the primary key. Does not add the s a p entry to the database.

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalService.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalService.java
@@ -187,6 +187,9 @@ public interface SAPEntryLocalService extends BaseLocalService,
 	public com.liferay.service.access.policy.model.SAPEntry fetchSAPEntryByUuidAndCompanyId(
 		java.lang.String uuid, long companyId);
 
+	public java.util.List<com.liferay.service.access.policy.model.SAPEntry> findDefaultSAPEntries(
+		long companyId, boolean defaultSAPEntry);
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery getActionableDynamicQuery();
 
@@ -283,7 +286,7 @@ public interface SAPEntryLocalService extends BaseLocalService,
 
 	public com.liferay.service.access.policy.model.SAPEntry updateSAPEntry(
 		long sapEntryId, java.lang.String allowedServiceSignatures,
-		boolean enabled, java.lang.String name,
+		boolean defaultSAPEntry, boolean enabled, java.lang.String name,
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws PortalException;

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalServiceUtil.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalServiceUtil.java
@@ -65,9 +65,9 @@ public class SAPEntryLocalServiceUtil {
 			defaultSAPEntry, enabled, name, titleMap, serviceContext);
 	}
 
-	public static void checkDefaultSAPEntry(long companyId)
+	public static void checkSystemSAPEntries(long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		getService().checkDefaultSAPEntry(companyId);
+		getService().checkSystemSAPEntries(companyId);
 	}
 
 	/**

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalServiceUtil.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalServiceUtil.java
@@ -211,6 +211,11 @@ public class SAPEntryLocalServiceUtil {
 		return getService().fetchSAPEntryByUuidAndCompanyId(uuid, companyId);
 	}
 
+	public static java.util.List<com.liferay.service.access.policy.model.SAPEntry> findDefaultSAPEntries(
+		long companyId, boolean defaultSAPEntry) {
+		return getService().findDefaultSAPEntries(companyId, defaultSAPEntry);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery getActionableDynamicQuery() {
 		return getService().getActionableDynamicQuery();
 	}
@@ -325,13 +330,13 @@ public class SAPEntryLocalServiceUtil {
 
 	public static com.liferay.service.access.policy.model.SAPEntry updateSAPEntry(
 		long sapEntryId, java.lang.String allowedServiceSignatures,
-		boolean enabled, java.lang.String name,
+		boolean defaultSAPEntry, boolean enabled, java.lang.String name,
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService()
 				   .updateSAPEntry(sapEntryId, allowedServiceSignatures,
-			enabled, name, titleMap, serviceContext);
+			defaultSAPEntry, enabled, name, titleMap, serviceContext);
 	}
 
 	public static SAPEntryLocalService getService() {

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalServiceWrapper.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalServiceWrapper.java
@@ -58,9 +58,9 @@ public class SAPEntryLocalServiceWrapper implements SAPEntryLocalService,
 	}
 
 	@Override
-	public void checkDefaultSAPEntry(long companyId)
+	public void checkSystemSAPEntries(long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		_sapEntryLocalService.checkDefaultSAPEntry(companyId);
+		_sapEntryLocalService.checkSystemSAPEntries(companyId);
 	}
 
 	/**

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalServiceWrapper.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryLocalServiceWrapper.java
@@ -218,6 +218,13 @@ public class SAPEntryLocalServiceWrapper implements SAPEntryLocalService,
 	}
 
 	@Override
+	public java.util.List<com.liferay.service.access.policy.model.SAPEntry> findDefaultSAPEntries(
+		long companyId, boolean defaultSAPEntry) {
+		return _sapEntryLocalService.findDefaultSAPEntries(companyId,
+			defaultSAPEntry);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery getActionableDynamicQuery() {
 		return _sapEntryLocalService.getActionableDynamicQuery();
 	}
@@ -347,12 +354,13 @@ public class SAPEntryLocalServiceWrapper implements SAPEntryLocalService,
 	@Override
 	public com.liferay.service.access.policy.model.SAPEntry updateSAPEntry(
 		long sapEntryId, java.lang.String allowedServiceSignatures,
-		boolean enabled, java.lang.String name,
+		boolean defaultSAPEntry, boolean enabled, java.lang.String name,
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _sapEntryLocalService.updateSAPEntry(sapEntryId,
-			allowedServiceSignatures, enabled, name, titleMap, serviceContext);
+			allowedServiceSignatures, defaultSAPEntry, enabled, name, titleMap,
+			serviceContext);
 	}
 
 	/**

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryService.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryService.java
@@ -51,8 +51,8 @@ public interface SAPEntryService extends BaseService {
 	 * Never modify or reference this interface directly. Always use {@link SAPEntryServiceUtil} to access the s a p entry remote service. Add custom service methods to {@link com.liferay.service.access.policy.service.impl.SAPEntryServiceImpl} and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
 	public com.liferay.service.access.policy.model.SAPEntry addSAPEntry(
-		java.lang.String allowedServiceSignatures, boolean enabled,
-		java.lang.String name,
+		java.lang.String allowedServiceSignatures, boolean defaultSAPEntry,
+		boolean enabled, java.lang.String name,
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws PortalException;
@@ -100,7 +100,7 @@ public interface SAPEntryService extends BaseService {
 
 	public com.liferay.service.access.policy.model.SAPEntry updateSAPEntry(
 		long sapEntryId, java.lang.String allowedServiceSignatures,
-		boolean enabled, java.lang.String name,
+		boolean defaultSAPEntry, boolean enabled, java.lang.String name,
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws PortalException;

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryServiceUtil.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryServiceUtil.java
@@ -43,14 +43,14 @@ public class SAPEntryServiceUtil {
 	 * Never modify this class directly. Add custom service methods to {@link com.liferay.service.access.policy.service.impl.SAPEntryServiceImpl} and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static com.liferay.service.access.policy.model.SAPEntry addSAPEntry(
-		java.lang.String allowedServiceSignatures, boolean enabled,
-		java.lang.String name,
+		java.lang.String allowedServiceSignatures, boolean defaultSAPEntry,
+		boolean enabled, java.lang.String name,
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService()
-				   .addSAPEntry(allowedServiceSignatures, enabled, name,
-			titleMap, serviceContext);
+				   .addSAPEntry(allowedServiceSignatures, defaultSAPEntry,
+			enabled, name, titleMap, serviceContext);
 	}
 
 	public static com.liferay.service.access.policy.model.SAPEntry deleteSAPEntry(
@@ -112,13 +112,13 @@ public class SAPEntryServiceUtil {
 
 	public static com.liferay.service.access.policy.model.SAPEntry updateSAPEntry(
 		long sapEntryId, java.lang.String allowedServiceSignatures,
-		boolean enabled, java.lang.String name,
+		boolean defaultSAPEntry, boolean enabled, java.lang.String name,
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService()
 				   .updateSAPEntry(sapEntryId, allowedServiceSignatures,
-			enabled, name, titleMap, serviceContext);
+			defaultSAPEntry, enabled, name, titleMap, serviceContext);
 	}
 
 	public static SAPEntryService getService() {

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryServiceWrapper.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/SAPEntryServiceWrapper.java
@@ -34,13 +34,13 @@ public class SAPEntryServiceWrapper implements SAPEntryService,
 
 	@Override
 	public com.liferay.service.access.policy.model.SAPEntry addSAPEntry(
-		java.lang.String allowedServiceSignatures, boolean enabled,
-		java.lang.String name,
+		java.lang.String allowedServiceSignatures, boolean defaultSAPEntry,
+		boolean enabled, java.lang.String name,
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _sapEntryService.addSAPEntry(allowedServiceSignatures, enabled,
-			name, titleMap, serviceContext);
+		return _sapEntryService.addSAPEntry(allowedServiceSignatures,
+			defaultSAPEntry, enabled, name, titleMap, serviceContext);
 	}
 
 	@Override
@@ -112,12 +112,13 @@ public class SAPEntryServiceWrapper implements SAPEntryService,
 	@Override
 	public com.liferay.service.access.policy.model.SAPEntry updateSAPEntry(
 		long sapEntryId, java.lang.String allowedServiceSignatures,
-		boolean enabled, java.lang.String name,
+		boolean defaultSAPEntry, boolean enabled, java.lang.String name,
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _sapEntryService.updateSAPEntry(sapEntryId,
-			allowedServiceSignatures, enabled, name, titleMap, serviceContext);
+			allowedServiceSignatures, defaultSAPEntry, enabled, name, titleMap,
+			serviceContext);
 	}
 
 	/**

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/persistence/SAPEntryPersistence.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/persistence/SAPEntryPersistence.java
@@ -583,6 +583,198 @@ public interface SAPEntryPersistence extends BasePersistence<SAPEntry> {
 	public int filterCountByCompanyId(long companyId);
 
 	/**
+	* Returns all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @return the matching s a p entries
+	*/
+	public java.util.List<SAPEntry> findByC_D(long companyId,
+		boolean defaultSAPEntry);
+
+	/**
+	* Returns a range of all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param start the lower bound of the range of s a p entries
+	* @param end the upper bound of the range of s a p entries (not inclusive)
+	* @return the range of matching s a p entries
+	*/
+	public java.util.List<SAPEntry> findByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end);
+
+	/**
+	* Returns an ordered range of all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param start the lower bound of the range of s a p entries
+	* @param end the upper bound of the range of s a p entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching s a p entries
+	*/
+	public java.util.List<SAPEntry> findByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SAPEntry> orderByComparator);
+
+	/**
+	* Returns the first s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching s a p entry
+	* @throws com.liferay.service.access.policy.NoSuchEntryException if a matching s a p entry could not be found
+	*/
+	public SAPEntry findByC_D_First(long companyId, boolean defaultSAPEntry,
+		com.liferay.portal.kernel.util.OrderByComparator<SAPEntry> orderByComparator)
+		throws com.liferay.service.access.policy.exception.NoSuchEntryException;
+
+	/**
+	* Returns the first s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching s a p entry, or <code>null</code> if a matching s a p entry could not be found
+	*/
+	public SAPEntry fetchByC_D_First(long companyId, boolean defaultSAPEntry,
+		com.liferay.portal.kernel.util.OrderByComparator<SAPEntry> orderByComparator);
+
+	/**
+	* Returns the last s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching s a p entry
+	* @throws com.liferay.service.access.policy.NoSuchEntryException if a matching s a p entry could not be found
+	*/
+	public SAPEntry findByC_D_Last(long companyId, boolean defaultSAPEntry,
+		com.liferay.portal.kernel.util.OrderByComparator<SAPEntry> orderByComparator)
+		throws com.liferay.service.access.policy.exception.NoSuchEntryException;
+
+	/**
+	* Returns the last s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching s a p entry, or <code>null</code> if a matching s a p entry could not be found
+	*/
+	public SAPEntry fetchByC_D_Last(long companyId, boolean defaultSAPEntry,
+		com.liferay.portal.kernel.util.OrderByComparator<SAPEntry> orderByComparator);
+
+	/**
+	* Returns the s a p entries before and after the current s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param sapEntryId the primary key of the current s a p entry
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next s a p entry
+	* @throws com.liferay.service.access.policy.NoSuchEntryException if a s a p entry with the primary key could not be found
+	*/
+	public SAPEntry[] findByC_D_PrevAndNext(long sapEntryId, long companyId,
+		boolean defaultSAPEntry,
+		com.liferay.portal.kernel.util.OrderByComparator<SAPEntry> orderByComparator)
+		throws com.liferay.service.access.policy.exception.NoSuchEntryException;
+
+	/**
+	* Returns all the s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @return the matching s a p entries that the user has permission to view
+	*/
+	public java.util.List<SAPEntry> filterFindByC_D(long companyId,
+		boolean defaultSAPEntry);
+
+	/**
+	* Returns a range of all the s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param start the lower bound of the range of s a p entries
+	* @param end the upper bound of the range of s a p entries (not inclusive)
+	* @return the range of matching s a p entries that the user has permission to view
+	*/
+	public java.util.List<SAPEntry> filterFindByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end);
+
+	/**
+	* Returns an ordered range of all the s a p entries that the user has permissions to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param start the lower bound of the range of s a p entries
+	* @param end the upper bound of the range of s a p entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching s a p entries that the user has permission to view
+	*/
+	public java.util.List<SAPEntry> filterFindByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SAPEntry> orderByComparator);
+
+	/**
+	* Returns the s a p entries before and after the current s a p entry in the ordered set of s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param sapEntryId the primary key of the current s a p entry
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next s a p entry
+	* @throws com.liferay.service.access.policy.NoSuchEntryException if a s a p entry with the primary key could not be found
+	*/
+	public SAPEntry[] filterFindByC_D_PrevAndNext(long sapEntryId,
+		long companyId, boolean defaultSAPEntry,
+		com.liferay.portal.kernel.util.OrderByComparator<SAPEntry> orderByComparator)
+		throws com.liferay.service.access.policy.exception.NoSuchEntryException;
+
+	/**
+	* Removes all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63; from the database.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	*/
+	public void removeByC_D(long companyId, boolean defaultSAPEntry);
+
+	/**
+	* Returns the number of s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @return the number of matching s a p entries
+	*/
+	public int countByC_D(long companyId, boolean defaultSAPEntry);
+
+	/**
+	* Returns the number of s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @return the number of matching s a p entries that the user has permission to view
+	*/
+	public int filterCountByC_D(long companyId, boolean defaultSAPEntry);
+
+	/**
 	* Returns the s a p entry where companyId = &#63; and name = &#63; or throws a {@link com.liferay.service.access.policy.NoSuchEntryException} if it could not be found.
 	*
 	* @param companyId the company ID

--- a/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/persistence/SAPEntryUtil.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/com/liferay/service/access/policy/service/persistence/SAPEntryUtil.java
@@ -763,6 +763,244 @@ public class SAPEntryUtil {
 	}
 
 	/**
+	* Returns all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @return the matching s a p entries
+	*/
+	public static List<SAPEntry> findByC_D(long companyId,
+		boolean defaultSAPEntry) {
+		return getPersistence().findByC_D(companyId, defaultSAPEntry);
+	}
+
+	/**
+	* Returns a range of all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param start the lower bound of the range of s a p entries
+	* @param end the upper bound of the range of s a p entries (not inclusive)
+	* @return the range of matching s a p entries
+	*/
+	public static List<SAPEntry> findByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end) {
+		return getPersistence().findByC_D(companyId, defaultSAPEntry, start, end);
+	}
+
+	/**
+	* Returns an ordered range of all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param start the lower bound of the range of s a p entries
+	* @param end the upper bound of the range of s a p entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching s a p entries
+	*/
+	public static List<SAPEntry> findByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end,
+		OrderByComparator<SAPEntry> orderByComparator) {
+		return getPersistence()
+				   .findByC_D(companyId, defaultSAPEntry, start, end,
+			orderByComparator);
+	}
+
+	/**
+	* Returns the first s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching s a p entry
+	* @throws com.liferay.service.access.policy.NoSuchEntryException if a matching s a p entry could not be found
+	*/
+	public static SAPEntry findByC_D_First(long companyId,
+		boolean defaultSAPEntry, OrderByComparator<SAPEntry> orderByComparator)
+		throws com.liferay.service.access.policy.exception.NoSuchEntryException {
+		return getPersistence()
+				   .findByC_D_First(companyId, defaultSAPEntry,
+			orderByComparator);
+	}
+
+	/**
+	* Returns the first s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching s a p entry, or <code>null</code> if a matching s a p entry could not be found
+	*/
+	public static SAPEntry fetchByC_D_First(long companyId,
+		boolean defaultSAPEntry, OrderByComparator<SAPEntry> orderByComparator) {
+		return getPersistence()
+				   .fetchByC_D_First(companyId, defaultSAPEntry,
+			orderByComparator);
+	}
+
+	/**
+	* Returns the last s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching s a p entry
+	* @throws com.liferay.service.access.policy.NoSuchEntryException if a matching s a p entry could not be found
+	*/
+	public static SAPEntry findByC_D_Last(long companyId,
+		boolean defaultSAPEntry, OrderByComparator<SAPEntry> orderByComparator)
+		throws com.liferay.service.access.policy.exception.NoSuchEntryException {
+		return getPersistence()
+				   .findByC_D_Last(companyId, defaultSAPEntry, orderByComparator);
+	}
+
+	/**
+	* Returns the last s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching s a p entry, or <code>null</code> if a matching s a p entry could not be found
+	*/
+	public static SAPEntry fetchByC_D_Last(long companyId,
+		boolean defaultSAPEntry, OrderByComparator<SAPEntry> orderByComparator) {
+		return getPersistence()
+				   .fetchByC_D_Last(companyId, defaultSAPEntry,
+			orderByComparator);
+	}
+
+	/**
+	* Returns the s a p entries before and after the current s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param sapEntryId the primary key of the current s a p entry
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next s a p entry
+	* @throws com.liferay.service.access.policy.NoSuchEntryException if a s a p entry with the primary key could not be found
+	*/
+	public static SAPEntry[] findByC_D_PrevAndNext(long sapEntryId,
+		long companyId, boolean defaultSAPEntry,
+		OrderByComparator<SAPEntry> orderByComparator)
+		throws com.liferay.service.access.policy.exception.NoSuchEntryException {
+		return getPersistence()
+				   .findByC_D_PrevAndNext(sapEntryId, companyId,
+			defaultSAPEntry, orderByComparator);
+	}
+
+	/**
+	* Returns all the s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @return the matching s a p entries that the user has permission to view
+	*/
+	public static List<SAPEntry> filterFindByC_D(long companyId,
+		boolean defaultSAPEntry) {
+		return getPersistence().filterFindByC_D(companyId, defaultSAPEntry);
+	}
+
+	/**
+	* Returns a range of all the s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param start the lower bound of the range of s a p entries
+	* @param end the upper bound of the range of s a p entries (not inclusive)
+	* @return the range of matching s a p entries that the user has permission to view
+	*/
+	public static List<SAPEntry> filterFindByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end) {
+		return getPersistence()
+				   .filterFindByC_D(companyId, defaultSAPEntry, start, end);
+	}
+
+	/**
+	* Returns an ordered range of all the s a p entries that the user has permissions to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param start the lower bound of the range of s a p entries
+	* @param end the upper bound of the range of s a p entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching s a p entries that the user has permission to view
+	*/
+	public static List<SAPEntry> filterFindByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end,
+		OrderByComparator<SAPEntry> orderByComparator) {
+		return getPersistence()
+				   .filterFindByC_D(companyId, defaultSAPEntry, start, end,
+			orderByComparator);
+	}
+
+	/**
+	* Returns the s a p entries before and after the current s a p entry in the ordered set of s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param sapEntryId the primary key of the current s a p entry
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next s a p entry
+	* @throws com.liferay.service.access.policy.NoSuchEntryException if a s a p entry with the primary key could not be found
+	*/
+	public static SAPEntry[] filterFindByC_D_PrevAndNext(long sapEntryId,
+		long companyId, boolean defaultSAPEntry,
+		OrderByComparator<SAPEntry> orderByComparator)
+		throws com.liferay.service.access.policy.exception.NoSuchEntryException {
+		return getPersistence()
+				   .filterFindByC_D_PrevAndNext(sapEntryId, companyId,
+			defaultSAPEntry, orderByComparator);
+	}
+
+	/**
+	* Removes all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63; from the database.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	*/
+	public static void removeByC_D(long companyId, boolean defaultSAPEntry) {
+		getPersistence().removeByC_D(companyId, defaultSAPEntry);
+	}
+
+	/**
+	* Returns the number of s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @return the number of matching s a p entries
+	*/
+	public static int countByC_D(long companyId, boolean defaultSAPEntry) {
+		return getPersistence().countByC_D(companyId, defaultSAPEntry);
+	}
+
+	/**
+	* Returns the number of s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	*
+	* @param companyId the company ID
+	* @param defaultSAPEntry the default s a p entry
+	* @return the number of matching s a p entries that the user has permission to view
+	*/
+	public static int filterCountByC_D(long companyId, boolean defaultSAPEntry) {
+		return getPersistence().filterCountByC_D(companyId, defaultSAPEntry);
+	}
+
+	/**
 	* Returns the s a p entry where companyId = &#63; and name = &#63; or throws a {@link com.liferay.service.access.policy.NoSuchEntryException} if it could not be found.
 	*
 	* @param companyId the company ID

--- a/modules/apps/service-access-policy/service-access-policy-service/service.xml
+++ b/modules/apps/service-access-policy/service-access-policy-service/service.xml
@@ -30,6 +30,10 @@
 		<finder name="CompanyId" return-type="Collection">
 			<finder-column name="companyId" />
 		</finder>
+		<finder name="C_D" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="defaultSAPEntry" />
+		</finder>
 		<finder name="C_N" return-type="SAPEntry">
 			<finder-column name="companyId" />
 			<finder-column name="name" case-sensitive="false" />

--- a/modules/apps/service-access-policy/service-access-policy-service/src/META-INF/sql/indexes.sql
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/META-INF/sql/indexes.sql
@@ -1,2 +1,3 @@
+create index IX_6D669D6F on SAPEntry (companyId, defaultSAPEntry);
 create index IX_90740311 on SAPEntry (companyId, name[$COLUMN_LENGTH:75$]);
 create index IX_AAAEBA0A on SAPEntry (uuid_[$COLUMN_LENGTH:75$], companyId);

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/SAPAccessControlPolicy.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/SAPAccessControlPolicy.java
@@ -68,6 +68,9 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 		List<String> systemSAPNames = getSystemSAPNames(companyId);
 		serviceAccessPolicyNames.addAll(systemSAPNames);
 
+		List<String> defaultSAPNames = getDefaultSAPNames(companyId);
+		serviceAccessPolicyNames.addAll(defaultSAPNames);
+
 		Set<String> allowedServiceSignatures = loadAllowedServiceSignatures(
 			companyId, serviceAccessPolicyNames);
 
@@ -138,6 +141,20 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 		}
 
 		return serviceAccessPolicyNames;
+	}
+
+	protected List<String> getDefaultSAPNames(long companyId) {
+		List<SAPEntry> defaultSAPEntries =
+			_sapEntryLocalService.findDefaultSAPEntries(companyId, true);
+
+		List<String> defaultSAPNames = new ArrayList<>(
+			defaultSAPEntries.size());
+
+		for (SAPEntry sapEntry : defaultSAPEntries) {
+			defaultSAPNames.add(sapEntry.getName());
+		}
+
+		return defaultSAPNames;
 	}
 
 	protected List<String> getSystemSAPNames(long companyId) {

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/SAPAccessControlPolicy.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/SAPAccessControlPolicy.java
@@ -98,6 +98,9 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 					setActiveServiceAccessPolicyNames(serviceAccessPolicyNames);
 			}
 
+			serviceAccessPolicyNames.add(
+				sapConfiguration.systemDefaultSAPEntryName());
+
 			boolean passwordBasedAuthentication = false;
 
 			if (accessControlContext != null) {
@@ -113,10 +116,6 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 			if (passwordBasedAuthentication) {
 				serviceAccessPolicyNames.add(
 					sapConfiguration.systemUserPasswordSAPEntryName());
-			}
-			else {
-				serviceAccessPolicyNames.add(
-					sapConfiguration.systemDefaultSAPEntryName());
 			}
 		}
 

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/SAPAccessControlPolicy.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/SAPAccessControlPolicy.java
@@ -88,7 +88,7 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 				"Unable to get service access policy configuration", ce);
 		}
 
-		if (sapConfiguration.requireDefaultSAPEntry() ||
+		if (sapConfiguration.useSystemSAPEntries() ||
 			(serviceAccessPolicyNames == null)) {
 
 			if (serviceAccessPolicyNames == null) {
@@ -112,11 +112,11 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 
 			if (passwordBasedAuthentication) {
 				serviceAccessPolicyNames.add(
-					sapConfiguration.defaultUserSAPEntryName());
+					sapConfiguration.systemUserPasswordSAPEntryName());
 			}
 			else {
 				serviceAccessPolicyNames.add(
-					sapConfiguration.defaultApplicationSAPEntryName());
+					sapConfiguration.systemDefaultSAPEntryName());
 			}
 		}
 

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/ServiceAccessPolicyManagerImpl.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/ServiceAccessPolicyManagerImpl.java
@@ -45,7 +45,7 @@ public class ServiceAccessPolicyManagerImpl
 		SAPConfiguration sapConfiguration = getSAPConfiguration(companyId);
 
 		if (sapConfiguration != null) {
-			return sapConfiguration.defaultApplicationSAPEntryName();
+			return sapConfiguration.systemDefaultSAPEntryName();
 		}
 
 		return null;
@@ -56,7 +56,7 @@ public class ServiceAccessPolicyManagerImpl
 		SAPConfiguration sapConfiguration = getSAPConfiguration(companyId);
 
 		if (sapConfiguration != null) {
-			return sapConfiguration.defaultUserSAPEntryName();
+			return sapConfiguration.systemUserPasswordSAPEntryName();
 		}
 
 		return null;

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/model/impl/SAPEntryImpl.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/model/impl/SAPEntryImpl.java
@@ -16,9 +16,14 @@ package com.liferay.service.access.policy.model.impl;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.module.configuration.ConfigurationFactoryUtil;
+import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.service.access.policy.configuration.SAPConfiguration;
+import com.liferay.service.access.policy.constants.SAPConstants;
 
 import java.util.List;
 
@@ -34,6 +39,27 @@ public class SAPEntryImpl extends SAPEntryBaseImpl {
 			getAllowedServiceSignatures(), StringPool.NEW_LINE);
 
 		return ListUtil.toList(allowedServiceSignatures);
+	}
+
+	@Override
+	public boolean isSystem() throws ConfigurationException {
+		SAPConfiguration sapConfiguration =
+			ConfigurationFactoryUtil.getConfiguration(
+				SAPConfiguration.class,
+				new CompanyServiceSettingsLocator(
+					getCompanyId(), SAPConstants.SERVICE_NAME));
+
+		if (getName().equals(sapConfiguration.systemDefaultSAPEntryName())) {
+			return true;
+		}
+
+		if (getName().equals(
+				sapConfiguration.systemUserPasswordSAPEntryName())) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/model/impl/SAPEntryModelImpl.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/model/impl/SAPEntryModelImpl.java
@@ -124,9 +124,10 @@ public class SAPEntryModelImpl extends BaseModelImpl<SAPEntry>
 				"value.object.column.bitmask.enabled.com.liferay.service.access.policy.model.SAPEntry"),
 			true);
 	public static final long COMPANYID_COLUMN_BITMASK = 1L;
-	public static final long NAME_COLUMN_BITMASK = 2L;
-	public static final long UUID_COLUMN_BITMASK = 4L;
-	public static final long SAPENTRYID_COLUMN_BITMASK = 8L;
+	public static final long DEFAULTSAPENTRY_COLUMN_BITMASK = 2L;
+	public static final long NAME_COLUMN_BITMASK = 4L;
+	public static final long UUID_COLUMN_BITMASK = 8L;
+	public static final long SAPENTRYID_COLUMN_BITMASK = 16L;
 
 	/**
 	 * Converts the soap model instance into a normal model instance.
@@ -470,7 +471,19 @@ public class SAPEntryModelImpl extends BaseModelImpl<SAPEntry>
 
 	@Override
 	public void setDefaultSAPEntry(boolean defaultSAPEntry) {
+		_columnBitmask |= DEFAULTSAPENTRY_COLUMN_BITMASK;
+
+		if (!_setOriginalDefaultSAPEntry) {
+			_setOriginalDefaultSAPEntry = true;
+
+			_originalDefaultSAPEntry = _defaultSAPEntry;
+		}
+
 		_defaultSAPEntry = defaultSAPEntry;
+	}
+
+	public boolean getOriginalDefaultSAPEntry() {
+		return _originalDefaultSAPEntry;
 	}
 
 	@JSON
@@ -788,6 +801,10 @@ public class SAPEntryModelImpl extends BaseModelImpl<SAPEntry>
 
 		sapEntryModelImpl._setModifiedDate = false;
 
+		sapEntryModelImpl._originalDefaultSAPEntry = sapEntryModelImpl._defaultSAPEntry;
+
+		sapEntryModelImpl._setOriginalDefaultSAPEntry = false;
+
 		sapEntryModelImpl._originalName = sapEntryModelImpl._name;
 
 		sapEntryModelImpl._columnBitmask = 0;
@@ -981,6 +998,8 @@ public class SAPEntryModelImpl extends BaseModelImpl<SAPEntry>
 	private boolean _setModifiedDate;
 	private String _allowedServiceSignatures;
 	private boolean _defaultSAPEntry;
+	private boolean _originalDefaultSAPEntry;
+	private boolean _setOriginalDefaultSAPEntry;
 	private boolean _enabled;
 	private String _name;
 	private String _originalName;

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/model/listener/PasswordPolicyModelListener.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/model/listener/PasswordPolicyModelListener.java
@@ -44,7 +44,7 @@ public class PasswordPolicyModelListener
 		}
 
 		try {
-			sapEntryLocalService.checkDefaultSAPEntry(
+			sapEntryLocalService.checkSystemSAPEntries(
 				passwordPolicy.getCompanyId());
 		}
 		catch (PortalException pe) {

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/http/SAPEntryServiceSoap.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/http/SAPEntryServiceSoap.java
@@ -70,8 +70,9 @@ import java.util.Map;
 @ProviderType
 public class SAPEntryServiceSoap {
 	public static com.liferay.service.access.policy.model.SAPEntrySoap addSAPEntry(
-		java.lang.String allowedServiceSignatures, boolean enabled,
-		java.lang.String name, java.lang.String[] titleMapLanguageIds,
+		java.lang.String allowedServiceSignatures, boolean defaultSAPEntry,
+		boolean enabled, java.lang.String name,
+		java.lang.String[] titleMapLanguageIds,
 		java.lang.String[] titleMapValues,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws RemoteException {
@@ -80,7 +81,7 @@ public class SAPEntryServiceSoap {
 					titleMapValues);
 
 			com.liferay.service.access.policy.model.SAPEntry returnValue = SAPEntryServiceUtil.addSAPEntry(allowedServiceSignatures,
-					enabled, name, titleMap, serviceContext);
+					defaultSAPEntry, enabled, name, titleMap, serviceContext);
 
 			return com.liferay.service.access.policy.model.SAPEntrySoap.toSoapModel(returnValue);
 		}
@@ -199,7 +200,7 @@ public class SAPEntryServiceSoap {
 
 	public static com.liferay.service.access.policy.model.SAPEntrySoap updateSAPEntry(
 		long sapEntryId, java.lang.String allowedServiceSignatures,
-		boolean enabled, java.lang.String name,
+		boolean defaultSAPEntry, boolean enabled, java.lang.String name,
 		java.lang.String[] titleMapLanguageIds,
 		java.lang.String[] titleMapValues,
 		com.liferay.portal.service.ServiceContext serviceContext)
@@ -209,8 +210,8 @@ public class SAPEntryServiceSoap {
 					titleMapValues);
 
 			com.liferay.service.access.policy.model.SAPEntry returnValue = SAPEntryServiceUtil.updateSAPEntry(sapEntryId,
-					allowedServiceSignatures, enabled, name, titleMap,
-					serviceContext);
+					allowedServiceSignatures, defaultSAPEntry, enabled, name,
+					titleMap, serviceContext);
 
 			return com.liferay.service.access.policy.model.SAPEntrySoap.toSoapModel(returnValue);
 		}

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
@@ -96,19 +96,21 @@ public class SAPEntryLocalServiceImpl extends SAPEntryLocalServiceBaseImpl {
 	}
 
 	@Override
-	public void checkDefaultSAPEntry(long companyId) throws PortalException {
+	public void checkSystemSAPEntries(long companyId) throws PortalException {
 		SAPConfiguration sapConfiguration =
 			configurationFactory.getConfiguration(
 				SAPConfiguration.class,
 				new CompanyServiceSettingsLocator(
 					companyId, SAPConstants.SERVICE_NAME));
 
-		SAPEntry applicationSAPEntry = sapEntryPersistence.fetchByC_N(
-			companyId, sapConfiguration.defaultApplicationSAPEntryName());
-		SAPEntry userSAPEntry = sapEntryPersistence.fetchByC_N(
-			companyId, sapConfiguration.defaultUserSAPEntryName());
+		SAPEntry systemDefaultSAPEntry = sapEntryPersistence.fetchByC_N(
+			companyId, sapConfiguration.systemDefaultSAPEntryName());
+		SAPEntry systemUserPasswordSAPEntry = sapEntryPersistence.fetchByC_N(
+			companyId, sapConfiguration.systemUserPasswordSAPEntryName());
 
-		if ((applicationSAPEntry != null) && (userSAPEntry != null)) {
+		if ((systemDefaultSAPEntry != null) &&
+			(systemUserPasswordSAPEntry != null)) {
+
 			return;
 		}
 
@@ -116,44 +118,44 @@ public class SAPEntryLocalServiceImpl extends SAPEntryLocalServiceBaseImpl {
 		Role guestRole = roleLocalService.getRole(
 			companyId, RoleConstants.GUEST);
 
-		if (applicationSAPEntry == null) {
+		if (systemDefaultSAPEntry == null) {
 			Map<Locale, String> titleMap = new HashMap<>();
 
 			titleMap.put(
 				LocaleUtil.getDefault(),
-				sapConfiguration.defaultApplicationSAPEntryDescription());
+				sapConfiguration.systemDefaultSAPEntryDescription());
 
-			applicationSAPEntry = addSAPEntry(
+			systemDefaultSAPEntry = addSAPEntry(
 				defaultUserId,
 				sapConfiguration.
-					defaultApplicationSAPEntryServiceSignatures(),
-				true, true, sapConfiguration.defaultApplicationSAPEntryName(),
+					systemDefaultSAPEntryServiceSignatures(),
+				true, true, sapConfiguration.systemDefaultSAPEntryName(),
 				titleMap, new ServiceContext());
 
 			resourcePermissionLocalService.setResourcePermissions(
-				applicationSAPEntry.getCompanyId(), SAPEntry.class.getName(),
+				systemDefaultSAPEntry.getCompanyId(), SAPEntry.class.getName(),
 				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(applicationSAPEntry.getSapEntryId()),
+				String.valueOf(systemDefaultSAPEntry.getSapEntryId()),
 				guestRole.getRoleId(), new String[] {ActionKeys.VIEW});
 		}
 
-		if (userSAPEntry == null) {
+		if (systemUserPasswordSAPEntry == null) {
 			Map<Locale, String> titleMap = new HashMap<>();
 
 			titleMap.put(
 				LocaleUtil.getDefault(),
-				sapConfiguration.defaultUserSAPEntryDescription());
+				sapConfiguration.systemUserPasswordSAPEntryDescription());
 
-			userSAPEntry = addSAPEntry(
+			systemUserPasswordSAPEntry = addSAPEntry(
 				defaultUserId,
-				sapConfiguration.defaultUserSAPEntryServiceSignatures(), true,
-				true, sapConfiguration.defaultUserSAPEntryName(), titleMap,
-				new ServiceContext());
+				sapConfiguration.systemUserPasswordSAPEntryServiceSignatures(),
+				true, true, sapConfiguration.systemUserPasswordSAPEntryName(),
+				titleMap, new ServiceContext());
 
 			resourcePermissionLocalService.setResourcePermissions(
-				userSAPEntry.getCompanyId(), SAPEntry.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(userSAPEntry.getSapEntryId()),
+				systemUserPasswordSAPEntry.getCompanyId(),
+				SAPEntry.class.getName(), ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(systemUserPasswordSAPEntry.getSapEntryId()),
 				guestRole.getRoleId(), new String[] {ActionKeys.VIEW});
 		}
 	}
@@ -226,7 +228,7 @@ public class SAPEntryLocalServiceImpl extends SAPEntryLocalServiceBaseImpl {
 			throw new DuplicateSAPEntryNameException();
 		}
 
-		if (sapEntry.isDefaultSAPEntry()) {
+		if (sapEntry.isSystem()) {
 			name = sapEntry.getName();
 		}
 

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
@@ -149,7 +149,7 @@ public class SAPEntryLocalServiceImpl extends SAPEntryLocalServiceBaseImpl {
 			systemUserPasswordSAPEntry = addSAPEntry(
 				defaultUserId,
 				sapConfiguration.systemUserPasswordSAPEntryServiceSignatures(),
-				true, true, sapConfiguration.systemUserPasswordSAPEntryName(),
+				false, true, sapConfiguration.systemUserPasswordSAPEntryName(),
 				titleMap, new ServiceContext());
 
 			resourcePermissionLocalService.setResourcePermissions(

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
@@ -185,6 +185,13 @@ public class SAPEntryLocalServiceImpl extends SAPEntryLocalServiceBaseImpl {
 	}
 
 	@Override
+	public List<SAPEntry> findDefaultSAPEntries(
+		long companyId, boolean defaultSAPEntry) {
+
+		return sapEntryPersistence.findByC_D(companyId, defaultSAPEntry);
+	}
+
+	@Override
 	public List<SAPEntry> getCompanySAPEntries(
 		long companyId, int start, int end) {
 

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryLocalServiceImpl.java
@@ -219,9 +219,9 @@ public class SAPEntryLocalServiceImpl extends SAPEntryLocalServiceBaseImpl {
 
 	@Override
 	public SAPEntry updateSAPEntry(
-			long sapEntryId, String allowedServiceSignatures, boolean enabled,
-			String name, Map<Locale, String> titleMap,
-			ServiceContext serviceContext)
+			long sapEntryId, String allowedServiceSignatures,
+			boolean defaultSAPEntry, boolean enabled, String name,
+			Map<Locale, String> titleMap, ServiceContext serviceContext)
 		throws PortalException {
 
 		SAPEntry sapEntry = sapEntryPersistence.findByPrimaryKey(sapEntryId);
@@ -237,6 +237,7 @@ public class SAPEntryLocalServiceImpl extends SAPEntryLocalServiceBaseImpl {
 
 		if (sapEntry.isSystem()) {
 			name = sapEntry.getName();
+			defaultSAPEntry = sapEntry.getDefaultSAPEntry();
 		}
 
 		name = StringUtil.trim(name);
@@ -244,6 +245,7 @@ public class SAPEntryLocalServiceImpl extends SAPEntryLocalServiceBaseImpl {
 		validate(name, titleMap);
 
 		sapEntry.setAllowedServiceSignatures(allowedServiceSignatures);
+		sapEntry.setDefaultSAPEntry(defaultSAPEntry);
 		sapEntry.setEnabled(enabled);
 		sapEntry.setName(name);
 		sapEntry.setTitleMap(titleMap);

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryServiceImpl.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/impl/SAPEntryServiceImpl.java
@@ -39,8 +39,9 @@ public class SAPEntryServiceImpl extends SAPEntryServiceBaseImpl {
 
 	@Override
 	public SAPEntry addSAPEntry(
-			String allowedServiceSignatures, boolean enabled, String name,
-			Map<Locale, String> titleMap, ServiceContext serviceContext)
+			String allowedServiceSignatures, boolean defaultSAPEntry,
+			boolean enabled, String name, Map<Locale, String> titleMap,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		PortletPermissionUtil.check(
@@ -48,8 +49,8 @@ public class SAPEntryServiceImpl extends SAPEntryServiceBaseImpl {
 			SAPActionKeys.ACTION_ADD_SAP_ENTRY);
 
 		return sapEntryLocalService.addSAPEntry(
-			getUserId(), allowedServiceSignatures, false, enabled, name,
-			titleMap, serviceContext);
+			getUserId(), allowedServiceSignatures, defaultSAPEntry, enabled,
+			name, titleMap, serviceContext);
 	}
 
 	@Override
@@ -110,17 +111,17 @@ public class SAPEntryServiceImpl extends SAPEntryServiceBaseImpl {
 
 	@Override
 	public SAPEntry updateSAPEntry(
-			long sapEntryId, String allowedServiceSignatures, boolean enabled,
-			String name, Map<Locale, String> titleMap,
-			ServiceContext serviceContext)
+			long sapEntryId, String allowedServiceSignatures,
+			boolean defaultSAPEntry, boolean enabled, String name,
+			Map<Locale, String> titleMap, ServiceContext serviceContext)
 		throws PortalException {
 
 		SAPEntryPermission.check(
 			getPermissionChecker(), sapEntryId, ActionKeys.UPDATE);
 
 		return sapEntryLocalService.updateSAPEntry(
-			sapEntryId, allowedServiceSignatures, enabled, name, titleMap,
-			serviceContext);
+			sapEntryId, allowedServiceSignatures, defaultSAPEntry, enabled,
+			name, titleMap, serviceContext);
 	}
 
 }

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/persistence/impl/SAPEntryPersistenceImpl.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/service/persistence/impl/SAPEntryPersistenceImpl.java
@@ -2811,6 +2811,895 @@ public class SAPEntryPersistenceImpl extends BasePersistenceImpl<SAPEntry>
 	}
 
 	private static final String _FINDER_COLUMN_COMPANYID_COMPANYID_2 = "sapEntry.companyId = ?";
+	public static final FinderPath FINDER_PATH_WITH_PAGINATION_FIND_BY_C_D = new FinderPath(SAPEntryModelImpl.ENTITY_CACHE_ENABLED,
+			SAPEntryModelImpl.FINDER_CACHE_ENABLED, SAPEntryImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_D",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				
+			Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			});
+	public static final FinderPath FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_D = new FinderPath(SAPEntryModelImpl.ENTITY_CACHE_ENABLED,
+			SAPEntryModelImpl.FINDER_CACHE_ENABLED, SAPEntryImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_D",
+			new String[] { Long.class.getName(), Boolean.class.getName() },
+			SAPEntryModelImpl.COMPANYID_COLUMN_BITMASK |
+			SAPEntryModelImpl.DEFAULTSAPENTRY_COLUMN_BITMASK);
+	public static final FinderPath FINDER_PATH_COUNT_BY_C_D = new FinderPath(SAPEntryModelImpl.ENTITY_CACHE_ENABLED,
+			SAPEntryModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_D",
+			new String[] { Long.class.getName(), Boolean.class.getName() });
+
+	/**
+	 * Returns all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @return the matching s a p entries
+	 */
+	@Override
+	public List<SAPEntry> findByC_D(long companyId, boolean defaultSAPEntry) {
+		return findByC_D(companyId, defaultSAPEntry, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param start the lower bound of the range of s a p entries
+	 * @param end the upper bound of the range of s a p entries (not inclusive)
+	 * @return the range of matching s a p entries
+	 */
+	@Override
+	public List<SAPEntry> findByC_D(long companyId, boolean defaultSAPEntry,
+		int start, int end) {
+		return findByC_D(companyId, defaultSAPEntry, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param start the lower bound of the range of s a p entries
+	 * @param end the upper bound of the range of s a p entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching s a p entries
+	 */
+	@Override
+	public List<SAPEntry> findByC_D(long companyId, boolean defaultSAPEntry,
+		int start, int end, OrderByComparator<SAPEntry> orderByComparator) {
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+			pagination = false;
+			finderPath = FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_D;
+			finderArgs = new Object[] { companyId, defaultSAPEntry };
+		}
+		else {
+			finderPath = FINDER_PATH_WITH_PAGINATION_FIND_BY_C_D;
+			finderArgs = new Object[] {
+					companyId, defaultSAPEntry,
+					
+					start, end, orderByComparator
+				};
+		}
+
+		List<SAPEntry> list = (List<SAPEntry>)FinderCacheUtil.getResult(finderPath,
+				finderArgs, this);
+
+		if ((list != null) && !list.isEmpty()) {
+			for (SAPEntry sapEntry : list) {
+				if ((companyId != sapEntry.getCompanyId()) ||
+						(defaultSAPEntry != sapEntry.getDefaultSAPEntry())) {
+					list = null;
+
+					break;
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(4 +
+						(orderByComparator.getOrderByFields().length * 3));
+			}
+			else {
+				query = new StringBundler(4);
+			}
+
+			query.append(_SQL_SELECT_SAPENTRY_WHERE);
+
+			query.append(_FINDER_COLUMN_C_D_COMPANYID_2);
+
+			query.append(_FINDER_COLUMN_C_D_DEFAULTSAPENTRY_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(query, _ORDER_BY_ENTITY_ALIAS,
+					orderByComparator);
+			}
+			else
+			 if (pagination) {
+				query.append(SAPEntryModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(companyId);
+
+				qPos.add(defaultSAPEntry);
+
+				if (!pagination) {
+					list = (List<SAPEntry>)QueryUtil.list(q, getDialect(),
+							start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<SAPEntry>)QueryUtil.list(q, getDialect(),
+							start, end);
+				}
+
+				cacheResult(list);
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, list);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching s a p entry
+	 * @throws com.liferay.service.access.policy.NoSuchEntryException if a matching s a p entry could not be found
+	 */
+	@Override
+	public SAPEntry findByC_D_First(long companyId, boolean defaultSAPEntry,
+		OrderByComparator<SAPEntry> orderByComparator)
+		throws NoSuchEntryException {
+		SAPEntry sapEntry = fetchByC_D_First(companyId, defaultSAPEntry,
+				orderByComparator);
+
+		if (sapEntry != null) {
+			return sapEntry;
+		}
+
+		StringBundler msg = new StringBundler(6);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("companyId=");
+		msg.append(companyId);
+
+		msg.append(", defaultSAPEntry=");
+		msg.append(defaultSAPEntry);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchEntryException(msg.toString());
+	}
+
+	/**
+	 * Returns the first s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching s a p entry, or <code>null</code> if a matching s a p entry could not be found
+	 */
+	@Override
+	public SAPEntry fetchByC_D_First(long companyId, boolean defaultSAPEntry,
+		OrderByComparator<SAPEntry> orderByComparator) {
+		List<SAPEntry> list = findByC_D(companyId, defaultSAPEntry, 0, 1,
+				orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching s a p entry
+	 * @throws com.liferay.service.access.policy.NoSuchEntryException if a matching s a p entry could not be found
+	 */
+	@Override
+	public SAPEntry findByC_D_Last(long companyId, boolean defaultSAPEntry,
+		OrderByComparator<SAPEntry> orderByComparator)
+		throws NoSuchEntryException {
+		SAPEntry sapEntry = fetchByC_D_Last(companyId, defaultSAPEntry,
+				orderByComparator);
+
+		if (sapEntry != null) {
+			return sapEntry;
+		}
+
+		StringBundler msg = new StringBundler(6);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("companyId=");
+		msg.append(companyId);
+
+		msg.append(", defaultSAPEntry=");
+		msg.append(defaultSAPEntry);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchEntryException(msg.toString());
+	}
+
+	/**
+	 * Returns the last s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching s a p entry, or <code>null</code> if a matching s a p entry could not be found
+	 */
+	@Override
+	public SAPEntry fetchByC_D_Last(long companyId, boolean defaultSAPEntry,
+		OrderByComparator<SAPEntry> orderByComparator) {
+		int count = countByC_D(companyId, defaultSAPEntry);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<SAPEntry> list = findByC_D(companyId, defaultSAPEntry, count - 1,
+				count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the s a p entries before and after the current s a p entry in the ordered set where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param sapEntryId the primary key of the current s a p entry
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next s a p entry
+	 * @throws com.liferay.service.access.policy.NoSuchEntryException if a s a p entry with the primary key could not be found
+	 */
+	@Override
+	public SAPEntry[] findByC_D_PrevAndNext(long sapEntryId, long companyId,
+		boolean defaultSAPEntry, OrderByComparator<SAPEntry> orderByComparator)
+		throws NoSuchEntryException {
+		SAPEntry sapEntry = findByPrimaryKey(sapEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SAPEntry[] array = new SAPEntryImpl[3];
+
+			array[0] = getByC_D_PrevAndNext(session, sapEntry, companyId,
+					defaultSAPEntry, orderByComparator, true);
+
+			array[1] = sapEntry;
+
+			array[2] = getByC_D_PrevAndNext(session, sapEntry, companyId,
+					defaultSAPEntry, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected SAPEntry getByC_D_PrevAndNext(Session session, SAPEntry sapEntry,
+		long companyId, boolean defaultSAPEntry,
+		OrderByComparator<SAPEntry> orderByComparator, boolean previous) {
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(6 +
+					(orderByComparator.getOrderByFields().length * 6));
+		}
+		else {
+			query = new StringBundler(3);
+		}
+
+		query.append(_SQL_SELECT_SAPENTRY_WHERE);
+
+		query.append(_FINDER_COLUMN_C_D_COMPANYID_2);
+
+		query.append(_FINDER_COLUMN_C_D_DEFAULTSAPENTRY_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields = orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(SAPEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(companyId);
+
+		qPos.add(defaultSAPEntry);
+
+		if (orderByComparator != null) {
+			Object[] values = orderByComparator.getOrderByConditionValues(sapEntry);
+
+			for (Object value : values) {
+				qPos.add(value);
+			}
+		}
+
+		List<SAPEntry> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @return the matching s a p entries that the user has permission to view
+	 */
+	@Override
+	public List<SAPEntry> filterFindByC_D(long companyId,
+		boolean defaultSAPEntry) {
+		return filterFindByC_D(companyId, defaultSAPEntry, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param start the lower bound of the range of s a p entries
+	 * @param end the upper bound of the range of s a p entries (not inclusive)
+	 * @return the range of matching s a p entries that the user has permission to view
+	 */
+	@Override
+	public List<SAPEntry> filterFindByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end) {
+		return filterFindByC_D(companyId, defaultSAPEntry, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the s a p entries that the user has permissions to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link SAPEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param start the lower bound of the range of s a p entries
+	 * @param end the upper bound of the range of s a p entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching s a p entries that the user has permission to view
+	 */
+	@Override
+	public List<SAPEntry> filterFindByC_D(long companyId,
+		boolean defaultSAPEntry, int start, int end,
+		OrderByComparator<SAPEntry> orderByComparator) {
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return findByC_D(companyId, defaultSAPEntry, start, end,
+				orderByComparator);
+		}
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(4 +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(4);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			query.append(_FILTER_SQL_SELECT_SAPENTRY_WHERE);
+		}
+		else {
+			query.append(_FILTER_SQL_SELECT_SAPENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		query.append(_FINDER_COLUMN_C_D_COMPANYID_2);
+
+		query.append(_FINDER_COLUMN_C_D_DEFAULTSAPENTRY_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			query.append(_FILTER_SQL_SELECT_SAPENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(query, _ORDER_BY_ENTITY_ALIAS,
+					orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(query, _ORDER_BY_ENTITY_TABLE,
+					orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				query.append(SAPEntryModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				query.append(SAPEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(query.toString(),
+				SAPEntry.class.getName(), _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				q.addEntity(_FILTER_ENTITY_ALIAS, SAPEntryImpl.class);
+			}
+			else {
+				q.addEntity(_FILTER_ENTITY_TABLE, SAPEntryImpl.class);
+			}
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(companyId);
+
+			qPos.add(defaultSAPEntry);
+
+			return (List<SAPEntry>)QueryUtil.list(q, getDialect(), start, end);
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the s a p entries before and after the current s a p entry in the ordered set of s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param sapEntryId the primary key of the current s a p entry
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next s a p entry
+	 * @throws com.liferay.service.access.policy.NoSuchEntryException if a s a p entry with the primary key could not be found
+	 */
+	@Override
+	public SAPEntry[] filterFindByC_D_PrevAndNext(long sapEntryId,
+		long companyId, boolean defaultSAPEntry,
+		OrderByComparator<SAPEntry> orderByComparator)
+		throws NoSuchEntryException {
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return findByC_D_PrevAndNext(sapEntryId, companyId,
+				defaultSAPEntry, orderByComparator);
+		}
+
+		SAPEntry sapEntry = findByPrimaryKey(sapEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SAPEntry[] array = new SAPEntryImpl[3];
+
+			array[0] = filterGetByC_D_PrevAndNext(session, sapEntry, companyId,
+					defaultSAPEntry, orderByComparator, true);
+
+			array[1] = sapEntry;
+
+			array[2] = filterGetByC_D_PrevAndNext(session, sapEntry, companyId,
+					defaultSAPEntry, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected SAPEntry filterGetByC_D_PrevAndNext(Session session,
+		SAPEntry sapEntry, long companyId, boolean defaultSAPEntry,
+		OrderByComparator<SAPEntry> orderByComparator, boolean previous) {
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(6 +
+					(orderByComparator.getOrderByFields().length * 6));
+		}
+		else {
+			query = new StringBundler(3);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			query.append(_FILTER_SQL_SELECT_SAPENTRY_WHERE);
+		}
+		else {
+			query.append(_FILTER_SQL_SELECT_SAPENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		query.append(_FINDER_COLUMN_C_D_COMPANYID_2);
+
+		query.append(_FINDER_COLUMN_C_D_DEFAULTSAPENTRY_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			query.append(_FILTER_SQL_SELECT_SAPENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields = orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					query.append(_ORDER_BY_ENTITY_ALIAS);
+				}
+				else {
+					query.append(_ORDER_BY_ENTITY_TABLE);
+				}
+
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					query.append(_ORDER_BY_ENTITY_ALIAS);
+				}
+				else {
+					query.append(_ORDER_BY_ENTITY_TABLE);
+				}
+
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				query.append(SAPEntryModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				query.append(SAPEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(query.toString(),
+				SAPEntry.class.getName(), _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			q.addEntity(_FILTER_ENTITY_ALIAS, SAPEntryImpl.class);
+		}
+		else {
+			q.addEntity(_FILTER_ENTITY_TABLE, SAPEntryImpl.class);
+		}
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(companyId);
+
+		qPos.add(defaultSAPEntry);
+
+		if (orderByComparator != null) {
+			Object[] values = orderByComparator.getOrderByConditionValues(sapEntry);
+
+			for (Object value : values) {
+				qPos.add(value);
+			}
+		}
+
+		List<SAPEntry> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the s a p entries where companyId = &#63; and defaultSAPEntry = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 */
+	@Override
+	public void removeByC_D(long companyId, boolean defaultSAPEntry) {
+		for (SAPEntry sapEntry : findByC_D(companyId, defaultSAPEntry,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+			remove(sapEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of s a p entries where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @return the number of matching s a p entries
+	 */
+	@Override
+	public int countByC_D(long companyId, boolean defaultSAPEntry) {
+		FinderPath finderPath = FINDER_PATH_COUNT_BY_C_D;
+
+		Object[] finderArgs = new Object[] { companyId, defaultSAPEntry };
+
+		Long count = (Long)FinderCacheUtil.getResult(finderPath, finderArgs,
+				this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(3);
+
+			query.append(_SQL_COUNT_SAPENTRY_WHERE);
+
+			query.append(_FINDER_COLUMN_C_D_COMPANYID_2);
+
+			query.append(_FINDER_COLUMN_C_D_DEFAULTSAPENTRY_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(companyId);
+
+				qPos.add(defaultSAPEntry);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of s a p entries that the user has permission to view where companyId = &#63; and defaultSAPEntry = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param defaultSAPEntry the default s a p entry
+	 * @return the number of matching s a p entries that the user has permission to view
+	 */
+	@Override
+	public int filterCountByC_D(long companyId, boolean defaultSAPEntry) {
+		if (!InlineSQLHelperUtil.isEnabled()) {
+			return countByC_D(companyId, defaultSAPEntry);
+		}
+
+		StringBundler query = new StringBundler(3);
+
+		query.append(_FILTER_SQL_COUNT_SAPENTRY_WHERE);
+
+		query.append(_FINDER_COLUMN_C_D_COMPANYID_2);
+
+		query.append(_FINDER_COLUMN_C_D_DEFAULTSAPENTRY_2);
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(query.toString(),
+				SAPEntry.class.getName(), _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			q.addScalar(COUNT_COLUMN_NAME,
+				com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(companyId);
+
+			qPos.add(defaultSAPEntry);
+
+			Long count = (Long)q.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	private static final String _FINDER_COLUMN_C_D_COMPANYID_2 = "sapEntry.companyId = ? AND ";
+	private static final String _FINDER_COLUMN_C_D_DEFAULTSAPENTRY_2 = "sapEntry.defaultSAPEntry = ?";
 	public static final FinderPath FINDER_PATH_FETCH_BY_C_N = new FinderPath(SAPEntryModelImpl.ENTITY_CACHE_ENABLED,
 			SAPEntryModelImpl.FINDER_CACHE_ENABLED, SAPEntryImpl.class,
 			FINDER_CLASS_NAME_ENTITY, "fetchByC_N",
@@ -3430,6 +4319,27 @@ public class SAPEntryPersistenceImpl extends BasePersistenceImpl<SAPEntry>
 				FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_COMPANYID,
 					args);
 				FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_COMPANYID,
+					args);
+			}
+
+			if ((sapEntryModelImpl.getColumnBitmask() &
+					FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_D.getColumnBitmask()) != 0) {
+				Object[] args = new Object[] {
+						sapEntryModelImpl.getOriginalCompanyId(),
+						sapEntryModelImpl.getOriginalDefaultSAPEntry()
+					};
+
+				FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_C_D, args);
+				FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_D,
+					args);
+
+				args = new Object[] {
+						sapEntryModelImpl.getCompanyId(),
+						sapEntryModelImpl.getDefaultSAPEntry()
+					};
+
+				FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_C_D, args);
+				FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_D,
 					args);
 			}
 		}

--- a/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/verify/SAPServiceVerifyProcess.java
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/com/liferay/service/access/policy/verify/SAPServiceVerifyProcess.java
@@ -53,7 +53,7 @@ public class SAPServiceVerifyProcess extends VerifyProcess {
 	protected void verifyDefaultSAPEntry() {
 		for (long companyId : PortalInstances.getCompanyIds()) {
 			try {
-				_sapEntryLocalService.checkDefaultSAPEntry(companyId);
+				_sapEntryLocalService.checkSystemSAPEntries(companyId);
 			}
 			catch (PortalException pe) {
 				_log.error(

--- a/modules/apps/service-access-policy/service-access-policy-service/src/service.properties
+++ b/modules/apps/service-access-policy/service-access-policy-service/src/service.properties
@@ -13,6 +13,6 @@
 ##
 
     build.namespace=SAP
-    build.number=1
+    build.number=3
     build.date=1438854976744
     build.auto.upgrade=true

--- a/modules/apps/service-access-policy/service-access-policy-test/test/integration/com/liferay/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
+++ b/modules/apps/service-access-policy/service-access-policy-test/test/integration/com/liferay/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
@@ -199,6 +199,14 @@ public class SAPEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_D() throws Exception {
+		_persistence.countByC_D(RandomTestUtil.nextLong(),
+			RandomTestUtil.randomBoolean());
+
+		_persistence.countByC_D(0L, RandomTestUtil.randomBoolean());
+	}
+
+	@Test
 	public void testCountByC_N() throws Exception {
 		_persistence.countByC_N(RandomTestUtil.nextLong(), StringPool.BLANK);
 

--- a/modules/apps/service-access-policy/service-access-policy-test/test/integration/com/liferay/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
+++ b/modules/apps/service-access-policy/service-access-policy-test/test/integration/com/liferay/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
@@ -45,7 +45,6 @@ import com.liferay.service.access.policy.service.persistence.SAPEntryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -65,9 +64,8 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class SAPEntryPersistenceTest {
-	@ClassRule
 	@Rule
-	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/service-access-policy/service-access-policy-web/src/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/service-access-policy/service-access-policy-web/src/META-INF/resources/edit_entry.jsp
@@ -69,6 +69,8 @@ if (sapEntry != null) {
 
 	<aui:input name="enabled" />
 
+	<aui:input disabled="<%= systemSAPEntry %>" helpMessage="default-sapentry-help" label="default" name="defaultSAPEntry" />
+
 	<aui:input name="title" required="<%= true %>" />
 
 	<aui:input helpMessage="allowed-service-signatures-help" name="allowedServiceSignatures" />

--- a/modules/apps/service-access-policy/service-access-policy-web/src/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/service-access-policy/service-access-policy-web/src/META-INF/resources/edit_entry.jsp
@@ -27,10 +27,10 @@ if (sapEntryId > 0) {
 	sapEntry = SAPEntryServiceUtil.getSAPEntry(sapEntryId);
 }
 
-boolean defaultSAPEntry = false;
+boolean systemSAPEntry = false;
 
 if (sapEntry != null) {
-	defaultSAPEntry = sapEntry.isDefaultSAPEntry();
+	systemSAPEntry = sapEntry.isSystem();
 }
 %>
 
@@ -53,7 +53,7 @@ if (sapEntry != null) {
 
 	<aui:model-context bean="<%= sapEntry %>" model="<%= SAPEntry.class %>" />
 
-	<aui:input disabled="<%= defaultSAPEntry %>" name="name" required="<%= true %>">
+	<aui:input disabled="<%= systemSAPEntry %>" name="name" required="<%= true %>">
 		<aui:validator errorMessage="this-field-is-required-and-must-contain-only-following-characters" name="custom">
 			function(val, fieldNode, ruleValue) {
 				var allowedCharacters = '<%= HtmlUtil.escapeJS(SAPEntryConstants.NAME_ALLOWED_CHARACTERS) %>';

--- a/modules/apps/service-access-policy/service-access-policy-web/src/META-INF/resources/entry_action.jsp
+++ b/modules/apps/service-access-policy/service-access-policy-web/src/META-INF/resources/entry_action.jsp
@@ -55,7 +55,7 @@ SAPEntry sapEntry = (SAPEntry)row.getObject();
 		/>
 	</c:if>
 
-	<c:if test="<%= !sapEntry.isDefaultSAPEntry() && SAPEntryPermission.contains(permissionChecker, sapEntry, ActionKeys.DELETE) %>">
+	<c:if test="<%= !sapEntry.isSystem() && SAPEntryPermission.contains(permissionChecker, sapEntry, ActionKeys.DELETE) %>">
 		<portlet:actionURL name="deleteSAPEntry" var="deleteURL">
 			<portlet:param name="redirect" value="<%= currentURL %>" />
 			<portlet:param name="sapEntryId" value="<%= String.valueOf(sapEntry.getSapEntryId()) %>" />

--- a/modules/apps/service-access-policy/service-access-policy-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/service-access-policy/service-access-policy-web/src/META-INF/resources/view.jsp
@@ -60,6 +60,10 @@ PortletURL portletURL = renderResponse.createRenderURL();
 			</c:if>
 		</liferay-ui:search-container-column-text>
 
+		<liferay-ui:search-container-column-text name="default">
+			<liferay-ui:icon cssClass='<%= sapEntry.isDefaultSAPEntry() ? "icon-check" : "icon-check-empty" %>' />
+		</liferay-ui:search-container-column-text>
+
 		<liferay-ui:search-container-column-jsp
 			align="right"
 			cssClass="entry-action"

--- a/modules/apps/service-access-policy/service-access-policy-web/src/com/liferay/service/access/policy/web/portlet/SAPPortlet.java
+++ b/modules/apps/service-access-policy/service-access-policy-web/src/com/liferay/service/access/policy/web/portlet/SAPPortlet.java
@@ -74,6 +74,8 @@ public class SAPPortlet extends MVCPortlet {
 
 		String allowedServiceSignatures = ParamUtil.getString(
 			actionRequest, "allowedServiceSignatures");
+		boolean defaultSAPEntry = ParamUtil.getBoolean(
+			actionRequest, "defaultSAPEntry");
 		boolean enabled = ParamUtil.getBoolean(actionRequest, "enabled");
 		String name = ParamUtil.getString(actionRequest, "name");
 		Map<Locale, String> titleMap = LocalizationUtil.getLocalizationMap(
@@ -84,13 +86,13 @@ public class SAPPortlet extends MVCPortlet {
 
 		if (sapEntryId > 0) {
 			_sapEntryService.updateSAPEntry(
-				sapEntryId, allowedServiceSignatures, enabled, name, titleMap,
-				serviceContext);
+				sapEntryId, allowedServiceSignatures, defaultSAPEntry, enabled,
+				name, titleMap, serviceContext);
 		}
 		else {
 			_sapEntryService.addSAPEntry(
-				allowedServiceSignatures, enabled, name, titleMap,
-				serviceContext);
+				allowedServiceSignatures, defaultSAPEntry, enabled, name,
+				titleMap, serviceContext);
 		}
 	}
 

--- a/modules/apps/service-access-policy/service-access-policy-web/src/content/Language.properties
+++ b/modules/apps/service-access-policy/service-access-policy-web/src/content/Language.properties
@@ -1,6 +1,7 @@
 action.ADD_SAP_ENTRY=Add Service Access Policy
 allowed-service-signatures=Allowed Service Signatures
 allowed-service-signatures-help=Enter each allowed service signatures separated by a new line. For example:\ncom.liferay.portal.service.UserService\ncom.liferay.portlet.documentlibrary.DLAppService#get*
+default-sapentry-help=If this is checked, policy will be applied to all incoming requests, including non-authenticated
 javax.portlet.title.com_liferay_service_access_policy_web_portlet_SAPPortlet=Service Access Policy
 model.resource.com.liferay.service.access.policy=Service Access Policy
 model.resource.com.liferay.service.access.policy.model.SAPEntry=Service Access Policy Entry


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-59163

Hi Mike,

today I tried the PoC for adding new Sync profile from sync-web plugin. I found out we need the story above.

Sync needs to declare a policy for non-authenticated users and currently it's not possible. Sync would need to update existing policy (DEFAULT_APP) with sync services, which portal admin can remove from the policy, and Sync then recreate the services, and admin remove, and again and again.

Therefore the multiple default profiles, where Sync can detect the policy exists, but admin can disable it or modify.

Thanks!