### PR TITLE
LPS-61340 AntiSamy as portal-security module

### DIFF
--- a/modules/portal-security/portal-security-antisamy/bnd.bnd
+++ b/modules/portal-security/portal-security-antisamy/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Portal Security AntiSamy
+Bundle-SymbolicName: com.liferay.portal.security.antisamy
+Bundle-Version: 1.0.0
+Include-Resource: classes

--- a/modules/portal-security/portal-security-antisamy/bnd.bnd
+++ b/modules/portal-security/portal-security-antisamy/bnd.bnd
@@ -1,4 +1,20 @@
 Bundle-Name: Liferay Portal Security AntiSamy
 Bundle-SymbolicName: com.liferay.portal.security.antisamy
 Bundle-Version: 1.0.0
-Include-Resource: classes
+Import-Package:\
+	!org.apache.commons.codec.*,\
+	!org.apache.commons.logging.*,\
+	!org.apache.xml.resolver.*,\
+	!sun.io,\
+	*
+Include-Resource: \
+	classes,\
+	@lib/antisamy.jar,\
+	@lib/batik-css.jar,\
+	@lib/batik-ext.jar,\
+	@lib/batik-util.jar,\
+	@lib/commons-httpclient.jar,\
+	@lib/nekohtml.jar,\
+	@lib/xercesImpl.jar,\
+	@lib/xml-apis.jar,\
+	@lib/xml-apis-ext.jar

--- a/modules/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/portal-security/portal-security-antisamy/build.gradle
@@ -6,8 +6,8 @@ processResources.dependsOn processSanitizerConfiguration
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "2.4.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
-
 	compile group: "org.owasp.antisamy", name: "antisamy", version: "1.5.3"
+	compile project(":apps:configuration-admin:configuration-admin-api")
 }
 
 downloadSanitizerConfiguration {

--- a/modules/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/portal-security/portal-security-antisamy/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "2.4.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
+
+	compile group: "org.owasp.antisamy", name: "antisamy", version: "1.5.3"
 }
 
 liferay {

--- a/modules/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/portal-security/portal-security-antisamy/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+	compile group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "2.4.1"
+	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
+}
+
+liferay {
+	deployDir = file("${liferayHome}/osgi/portal")
+}

--- a/modules/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/portal-security/portal-security-antisamy/build.gradle
@@ -1,3 +1,8 @@
+task downloadSanitizerConfiguration(type: AntGetDownload)
+task processSanitizerConfiguration (type: Copy, dependsOn: downloadSanitizerConfiguration)
+
+processResources.dependsOn processSanitizerConfiguration
+
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "2.4.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
@@ -5,6 +10,36 @@ dependencies {
 	compile group: "org.owasp.antisamy", name: "antisamy", version: "1.5.3"
 }
 
+downloadSanitizerConfiguration {
+	sourceUrl = 'https://owaspantisamy.googlecode.com/files/antisamy-ebay-1.4.4.xml'
+	target = file ('build/tmp/antisamy-ebay-1.4.4.xml')
+}
+
+processSanitizerConfiguration {
+	from ('build/tmp') {
+		include ('antisamy-ebay-1.4.4.xml')
+		rename ('antisamy-ebay-1.4.4.xml', 'sanitizer-configuration.xml')
+		filter {
+			line -> line.contains('<directive name="maxInputSize" value="20000"/>') ? line.replace('20000', '200000') : line
+		}
+	}
+
+	into 'classes'
+}
+
 liferay {
 	deployDir = file("${liferayHome}/osgi/portal")
+}
+
+class AntGetDownload extends DefaultTask {
+	@Input
+	String sourceUrl
+
+	@OutputFile
+	File target
+
+	@TaskAction
+	void download() {
+		ant.get(src: sourceUrl, dest: target)
+	}
 }

--- a/modules/portal-security/portal-security-antisamy/build.xml
+++ b/modules/portal-security/portal-security-antisamy/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../build-module.xml" />
+</project>

--- a/modules/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/AntiSamySanitizerImpl.java
+++ b/modules/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/AntiSamySanitizerImpl.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.antisamy;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.StreamUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.util.Map;
+
+import org.owasp.validator.html.AntiSamy;
+import org.owasp.validator.html.CleanResults;
+import org.owasp.validator.html.Policy;
+import org.owasp.validator.html.PolicyException;
+
+/**
+ * @author Zsolt Balogh
+ * @author Brian Wing Shun Chan
+ */
+public class AntiSamySanitizerImpl implements Sanitizer {
+
+	@Override
+	public byte[] sanitize(
+		long companyId, long groupId, long userId, String className,
+		long classPK, String contentType, String[] modes, byte[] bytes,
+		Map<String, Object> options) {
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Sanitizing " + className + "#" + classPK);
+		}
+
+		return bytes;
+	}
+
+	@Override
+	public void sanitize(
+			long companyId, long groupId, long userId, String className,
+			long classPK, String contentType, String[] modes,
+			InputStream inputStream, OutputStream outputStream,
+			Map<String, Object> options)
+		throws SanitizerException {
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Sanitizing " + className + "#" + classPK);
+		}
+
+		try {
+			StreamUtil.transfer(inputStream, outputStream);
+		}
+		catch (IOException ioe) {
+			throw new SanitizerException(ioe);
+		}
+	}
+
+	@Override
+	public String sanitize(
+			long companyId, long groupId, long userId, String className,
+			long classPK, String contentType, String[] modes, String s,
+			Map<String, Object> options)
+		throws SanitizerException {
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Sanitizing " + className + "#" + classPK);
+		}
+
+		if (!_initialized) {
+			_init();
+		}
+
+		if (_disabled) {
+			return s;
+		}
+
+		if (Validator.isNull(contentType) ||
+			!contentType.equals(ContentTypes.TEXT_HTML)) {
+
+			return s;
+		}
+
+		try {
+			AntiSamy antiSamy = new AntiSamy();
+
+			CleanResults cleanResults = antiSamy.scan(s, _policy);
+
+			return cleanResults.getCleanHTML();
+		}
+		catch (Exception e) {
+			_log.error("Unable to sanitize input", e);
+
+			throw new SanitizerException(e);
+		}
+	}
+
+	private void _init() {
+		Class<?> clazz = getClass();
+
+		ClassLoader classLoader = clazz.getClassLoader();
+
+		InputStream inputStream = classLoader.getResourceAsStream(
+			"sanitizer-configuration.xml");
+
+		if (inputStream == null) {
+			_log.error("Configuration could not be found");
+
+			_disabled = true;
+
+			return;
+		}
+
+		try {
+			_policy = Policy.getInstance(inputStream);
+		}
+		catch (PolicyException pe) {
+			_log.error("Policy could not be initialized", pe);
+
+			_disabled = true;
+		}
+	}
+
+	private static Log _log = LogFactoryUtil.getLog(
+		AntiSamySanitizerImpl.class);
+
+	private boolean _disabled;
+	private boolean _initialized;
+	private Policy _policy;
+
+}

--- a/modules/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/AntiSamySanitizerImpl.java
+++ b/modules/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/AntiSamySanitizerImpl.java
@@ -28,9 +28,6 @@ import java.io.OutputStream;
 
 import java.util.Map;
 
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-
 import org.owasp.validator.html.AntiSamy;
 import org.owasp.validator.html.CleanResults;
 import org.owasp.validator.html.Policy;
@@ -40,7 +37,6 @@ import org.owasp.validator.html.PolicyException;
  * @author Zsolt Balogh
  * @author Brian Wing Shun Chan
  */
-@Component(immediate = true)
 public class AntiSamySanitizerImpl implements Sanitizer {
 
 	@Override
@@ -107,8 +103,7 @@ public class AntiSamySanitizerImpl implements Sanitizer {
 		}
 	}
 
-	@Activate
-	protected void activate() {
+	protected void init() {
 		Class<?> clazz = getClass();
 
 		ClassLoader classLoader = clazz.getClassLoader();

--- a/modules/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/AntiSamySanitizerPublisher.java
+++ b/modules/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/AntiSamySanitizerPublisher.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.antisamy;
+
+import aQute.bnd.annotation.metatype.Configurable;
+
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.security.antisamy.configuration.AntiSamyConfiguration;
+
+import java.util.Map;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * @author Tomas Polesovsky
+ */
+@Component(
+	configurationPid = "com.liferay.portal.security.antisamy.configuration.AntiSamyConfiguration",
+	immediate = true
+)
+public class AntiSamySanitizerPublisher {
+
+	@Activate
+	protected void activate(
+		BundleContext bundleContext, Map<String, Object> properties) {
+
+		AntiSamyConfiguration antiSamyConfiguration =
+			Configurable.createConfigurable(
+				AntiSamyConfiguration.class, properties);
+
+		if (!antiSamyConfiguration.enabled()) {
+			return;
+		}
+
+		AntiSamySanitizerImpl antiSamySanitizer = new AntiSamySanitizerImpl();
+
+		antiSamySanitizer.init();
+
+		_antiSamySanitizerRegistration = bundleContext.registerService(
+			Sanitizer.class, antiSamySanitizer, null);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_antiSamySanitizerRegistration != null) {
+			_antiSamySanitizerRegistration.unregister();
+		}
+	}
+
+	@Modified
+	protected void modified(
+		BundleContext bundleContext, Map<String, Object> properties) {
+
+		deactivate();
+
+		activate(bundleContext, properties);
+	}
+
+	private ServiceRegistration<Sanitizer> _antiSamySanitizerRegistration;
+
+}

--- a/modules/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/configuration/AntiSamyConfiguration.java
+++ b/modules/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/configuration/AntiSamyConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.antisamy.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.configuration.admin.ConfigurationAdmin;
+
+/**
+ * @author Tomas Polesovsky
+ */
+@ConfigurationAdmin(category = "platform")
+@Meta.OCD(
+	id = "com.liferay.portal.security.antisamy.configuration.AntiSamyConfiguration"
+)
+public interface AntiSamyConfiguration {
+
+	@Meta.AD(deflt = "true", required = false)
+	public boolean enabled();
+
+}


### PR DESCRIPTION
Hi Mike,

here are basically 2 things:
1, Move AntiSamy among portal-security modules
2, Create configuration for portal adminstrator to be able to disable the module

Maybe we could introduce one other property into the configuration - anti-samy-rules XML so that portal admins are able to modify AntiSamy rules. Should be simple to provide that XML into `AntiSamySanitizerImpl.init()` method.

Thanks