### PR TITLE
LPS-61464 Fix Facebook Connect Struts impl

### DIFF
--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/FacebookConnectImpl.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/FacebookConnectImpl.java
@@ -56,7 +56,7 @@ public class FacebookConnectImpl implements FacebookConnect {
 			getFacebookConnectConfiguration(companyId);
 
 		String url = HttpUtil.addParameter(
-			facebookConnectConfiguration.oauthAuthURL(), "client_id",
+			facebookConnectConfiguration.oauthTokenURL(), "client_id",	
 			facebookConnectConfiguration.appId());
 
 		String facebookConnectRedirectURL =

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/FacebookConnectImpl.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/FacebookConnectImpl.java
@@ -56,7 +56,7 @@ public class FacebookConnectImpl implements FacebookConnect {
 			getFacebookConnectConfiguration(companyId);
 
 		String url = HttpUtil.addParameter(
-			facebookConnectConfiguration.oauthTokenURL(), "client_id",	
+			facebookConnectConfiguration.oauthTokenURL(), "client_id",
 			facebookConnectConfiguration.appId());
 
 		String facebookConnectRedirectURL =

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/module/configuration/FacebookConnectConfiguration.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/module/configuration/FacebookConnectConfiguration.java
@@ -45,7 +45,7 @@ public interface FacebookConnectConfiguration {
 	public String oauthAuthURL();
 
 	@Meta.AD(
-		deflt = "http://localhost:8080/c/login/facebook_connect_oauth",
+		deflt = "http://localhost:8080/c/facebook_connect/facebook_connect_oauth",
 		required = false
 	)
 	public String oauthRedirectURL();

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/AssociateFacebookUserMVCRenderCommand.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/AssociateFacebookUserMVCRenderCommand.java
@@ -14,16 +14,6 @@
 
 package com.liferay.portal.security.sso.facebook.connect.portlet.action;
 
-import javax.portlet.PortletException;
-import javax.portlet.PortletRequest;
-import javax.portlet.RenderRequest;
-import javax.portlet.RenderResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-
 import com.liferay.portal.kernel.facebook.FacebookConnect;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -31,11 +21,21 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.auth.PrincipalException;
-import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectWebKeys;
 import com.liferay.portal.service.UserLocalService;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PortletKeys;
+
+import javax.portlet.PortletException;
+import javax.portlet.PortletRequest;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Stian Sigvartsen
@@ -43,48 +43,55 @@ import com.liferay.portal.util.PortletKeys;
 @Component(
 	immediate = true,
 	property = {
-		"mvc.command.name=/login/associate_facebook_user",
-		"javax.portlet.name=" + PortletKeys.LOGIN,
-		"javax.portlet.name=" + PortletKeys.FAST_LOGIN,
+		"javax.portlet.name=", "javax.portlet.name=" + PortletKeys.LOGIN,
+		"mvc.command.name=/login/associate_facebook_user" + PortletKeys.FAST_LOGIN
 	},
 	service = MVCRenderCommand.class
 )
-public class AssociateFacebookUserMVCRenderCommand implements MVCRenderCommand { 
+public class AssociateFacebookUserMVCRenderCommand implements MVCRenderCommand {
 
 	@Override
 	public String render(RenderRequest request, RenderResponse response)
-			throws PortletException {
+		throws PortletException {
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		if (!_facebookConnect.isEnabled(themeDisplay.getCompanyId())) {
-			
 			throw new PortletException(
-					new PrincipalException.MustBeEnabled(themeDisplay.getCompanyId(), FacebookConnect.class.getName()));
+					new PrincipalException.MustBeEnabled(
+						themeDisplay.getCompanyId(),
+						FacebookConnect.class.getName()));
 		}
-		
-		HttpServletRequest httpServletRequest = PortalUtil.getOriginalServletRequest(PortalUtil.getHttpServletRequest(request));
-		
+
+		HttpServletRequest httpServletRequest =
+			PortalUtil.getOriginalServletRequest(
+				PortalUtil.getHttpServletRequest(request));
+
 		HttpSession session = httpServletRequest.getSession(true);
 
 		long facebookIncompleteUserId = ParamUtil.getLong(request, "userId");
+
 		if (!Validator.isNull(facebookIncompleteUserId)) {
-			
-			User user = _userLocalService.fetchUser(facebookIncompleteUserId);			
+			User user = _userLocalService.fetchUser(facebookIncompleteUserId);
 			return renderUpdateAccount(request, user);
 		}
 
 		// This situation might happen if the browser back button is used
+
 		return "/login.jsp";
 	}
 
-	protected String renderUpdateAccount(
-			PortletRequest request, User user)
+	protected String renderUpdateAccount(PortletRequest request, User user)
 		throws PortletException {
-		
-		request.setAttribute("selUser", user);		
+
+		request.setAttribute("selUser", user);
 		return "/update_account.jsp";
+	}
+
+	@Reference(unbind = "-")
+	protected void setFacebookConnect(FacebookConnect facebookConnect) {
+		_facebookConnect = facebookConnect;
 	}
 
 	@Reference(unbind = "-")
@@ -92,12 +99,7 @@ public class AssociateFacebookUserMVCRenderCommand implements MVCRenderCommand {
 		_userLocalService = userLocalService;
 	}
 
-	@Reference
-	protected void setFacebookConnect(FacebookConnect facebookConnect) {
-		_facebookConnect = facebookConnect;
-	}
-	
-	private FacebookConnect _facebookConnect;
-	private UserLocalService _userLocalService;
-	
+	private volatile FacebookConnect _facebookConnect;
+	private volatile UserLocalService _userLocalService;
+
 }

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/AssociateFacebookUserMVCRenderCommand.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/AssociateFacebookUserMVCRenderCommand.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.sso.facebook.connect.portlet.action;
+
+import javax.portlet.PortletException;
+import javax.portlet.PortletRequest;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.liferay.portal.kernel.facebook.FacebookConnect;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.User;
+import com.liferay.portal.security.auth.PrincipalException;
+import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectWebKeys;
+import com.liferay.portal.service.UserLocalService;
+import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.PortletKeys;
+
+/**
+ * @author Stian Sigvartsen
+ */
+@Component(
+	immediate = true,
+	property = {
+		"mvc.command.name=/login/associate_facebook_user",
+		"javax.portlet.name=" + PortletKeys.LOGIN,
+		"javax.portlet.name=" + PortletKeys.FAST_LOGIN,
+	},
+	service = MVCRenderCommand.class
+)
+public class AssociateFacebookUserMVCRenderCommand implements MVCRenderCommand { 
+
+	@Override
+	public String render(RenderRequest request, RenderResponse response)
+			throws PortletException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		if (!_facebookConnect.isEnabled(themeDisplay.getCompanyId())) {
+			
+			throw new PortletException(
+					new PrincipalException.MustBeEnabled(themeDisplay.getCompanyId(), FacebookConnect.class.getName()));
+		}
+		
+		HttpServletRequest httpServletRequest = PortalUtil.getOriginalServletRequest(PortalUtil.getHttpServletRequest(request));
+		
+		HttpSession session = httpServletRequest.getSession(true);
+
+		long facebookIncompleteUserId = ParamUtil.getLong(request, "userId");
+		if (!Validator.isNull(facebookIncompleteUserId)) {
+			
+			User user = _userLocalService.fetchUser(facebookIncompleteUserId);			
+			return renderUpdateAccount(request, user);
+		}
+
+		// This situation might happen if the browser back button is used
+		return "/login.jsp";
+	}
+
+	protected String renderUpdateAccount(
+			PortletRequest request, User user)
+		throws PortletException {
+		
+		request.setAttribute("selUser", user);		
+		return "/update_account.jsp";
+	}
+
+	@Reference(unbind = "-")
+	protected void setUserLocalService(UserLocalService userLocalService) {
+		_userLocalService = userLocalService;
+	}
+
+	@Reference
+	protected void setFacebookConnect(FacebookConnect facebookConnect) {
+		_facebookConnect = facebookConnect;
+	}
+	
+	private FacebookConnect _facebookConnect;
+	private UserLocalService _userLocalService;
+	
+}

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
@@ -66,7 +66,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"/common/referer_jsp.jsp=/common/referer_jsp.jsp",
-		"path=/login/facebook_connect_oauth",
+		"path=/facebook_connect/facebook_connect_oauth",
 		"portlet.login.login=portlet.login.login",
 		"portlet.login.update_account=portlet.login.update_account"
 	},

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
@@ -194,7 +194,7 @@ public class FacebookConnectAction extends BaseStrutsAction {
 			PortletRequest.RENDER_PHASE);
 
 		portletURL.setParameter("saveLastPath", Boolean.FALSE.toString());
-		portletURL.setParameter("struts_action", "/login/update_account");
+		portletURL.setParameter("mvcRenderCommandName", "/login/associate_facebook_user");
 
 		PortletURL redirectURL = PortletURLFactoryUtil.create(
 			request, PortletKeys.FAST_LOGIN, themeDisplay.getPlid(),

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
@@ -218,7 +218,7 @@ public class FacebookConnectAction extends BaseStrutsAction {
 
 		JSONObject jsonObject = _facebookConnect.getGraphResources(
 			companyId, "/me", token,
-			"id,email,first_name,last_name,gender");
+			"id,email,first_name,last_name,gender,verified");
 
 		if ((jsonObject == null) ||
 			(jsonObject.getJSONObject("error") != null)) {

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
@@ -196,17 +196,7 @@ public class FacebookConnectAction extends BaseStrutsAction {
 		portletURL.setParameter("saveLastPath", Boolean.FALSE.toString());
 		portletURL.setParameter("mvcRenderCommandName", "/login/associate_facebook_user");
 
-		PortletURL redirectURL = PortletURLFactoryUtil.create(
-			request, PortletKeys.FAST_LOGIN, themeDisplay.getPlid(),
-			PortletRequest.RENDER_PHASE);
-
-		redirectURL.setParameter("struts_action", "/login/login_redirect");
-		redirectURL.setParameter("emailAddress", user.getEmailAddress());
-		redirectURL.setParameter("anonymousUser", Boolean.FALSE.toString());
-		redirectURL.setPortletMode(PortletMode.VIEW);
-		redirectURL.setWindowState(LiferayWindowState.POP_UP);
-
-		portletURL.setParameter("redirect", redirectURL.toString());
+		portletURL.setParameter("redirect", ParamUtil.getString(request, "redirect"));
 		portletURL.setParameter("userId", String.valueOf(user.getUserId()));
 		portletURL.setParameter("emailAddress", user.getEmailAddress());
 		portletURL.setParameter("firstName", user.getFirstName());

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/portlet/action/FacebookConnectAction.java
@@ -194,9 +194,11 @@ public class FacebookConnectAction extends BaseStrutsAction {
 			PortletRequest.RENDER_PHASE);
 
 		portletURL.setParameter("saveLastPath", Boolean.FALSE.toString());
-		portletURL.setParameter("mvcRenderCommandName", "/login/associate_facebook_user");
+		portletURL.setParameter(
+			"mvcRenderCommandName", "/login/associate_facebook_user");
 
-		portletURL.setParameter("redirect", ParamUtil.getString(request, "redirect"));
+		portletURL.setParameter(
+			"redirect", ParamUtil.getString(request, "redirect"));
 		portletURL.setParameter("userId", String.valueOf(user.getUserId()));
 		portletURL.setParameter("emailAddress", user.getEmailAddress());
 		portletURL.setParameter("firstName", user.getFirstName());

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/web/portlet/path/AuthPublicPath.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/web/portlet/path/AuthPublicPath.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.security.sso.facebook.connect.web.portlet.path;
 
 import org.osgi.service.component.annotations.Component;
@@ -7,9 +21,7 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	immediate = true,
-	property = {
-		"auth.public.path=/facebook_connect/facebook_connect_oauth"
-	},
+	property = {"auth.public.path=/facebook_connect/facebook_connect_oauth"},
 	service = Object.class
 )
 public class AuthPublicPath {

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/web/portlet/path/AuthPublicPath.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/web/portlet/path/AuthPublicPath.java
@@ -1,0 +1,16 @@
+package com.liferay.portal.security.sso.facebook.connect.web.portlet.path;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Stian Sigvartsen
+ */
+@Component(
+	immediate = true,
+	property = {
+		"auth.public.path=/facebook_connect/facebook_connect_oauth"
+	},
+	service = Object.class
+)
+public class AuthPublicPath {
+}

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/resources/META-INF/resources/html/portlet/login/navigation/facebook.jsp
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/resources/META-INF/resources/html/portlet/login/navigation/facebook.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/html/portlet/login/navigation/init.jsp" %>
 
 <portlet:renderURL var="loginRedirectURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-	<portlet:param name="struts_action" value="/login/login_redirect" />
+	<portlet:param name="mvcRenderCommandName" value="/login/login_redirect" />
 </portlet:renderURL>
 
 <%

--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/resources/META-INF/resources/html/portlet/login/navigation/facebook.jsp
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/resources/META-INF/resources/html/portlet/login/navigation/facebook.jsp
@@ -25,13 +25,13 @@ String facebookAuthRedirectURL = (String)request.getAttribute(FacebookConnectWeb
 String facebookAuthURL = (String)request.getAttribute(FacebookConnectWebKeys.FACEBOOK_AUTH_URL);
 String facebookAppId = (String)request.getAttribute(FacebookConnectWebKeys.FACEBOOK_APP_ID);
 
-facebookAuthRedirectURL = HttpUtil.addParameter(facebookAuthRedirectURL, "redirect", HttpUtil.encodeURL(loginRedirectURL));
+facebookAuthRedirectURL = HttpUtil.addParameter(facebookAuthRedirectURL, "redirect", loginRedirectURL);
 
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "client_id", facebookAppId);
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "redirect_uri", facebookAuthRedirectURL);
 facebookAuthURL = HttpUtil.addParameter(facebookAuthURL, "scope", "email");
 
-String taglibOpenFacebookConnectLoginWindow = "javascript:var facebookConnectLoginWindow = window.open('" + facebookAuthURL + "', 'facebook', 'align=center,directories=no,height=560,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no,width=1000'); void(''); facebookConnectLoginWindow.focus();";
+String taglibOpenFacebookConnectLoginWindow = "javascript:var facebookConnectLoginWindow = window.open('" + HttpUtil.encodeURL(facebookAuthURL) + "', 'facebook', 'align=center,directories=no,height=560,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no,width=1000'); void(''); facebookConnectLoginWindow.focus();";
 %>
 
 <liferay-ui:icon


### PR DESCRIPTION
Hi Mike.

Tomas and I thought it would be sensible to split the Facebook Connect fix into two issues. This PR is to fix the current Struts implementation. Once merged this will help refactor LPS-60139 into smaller chunks.

The only functional difference is that the redirect URL generated in facebook.jsp is now used at the end of the process when associating an existing incomplete user, rather than re-generating it with less contextual info available. This means no matter what the login process flow is, the exit is consistent.

Are you able to review this in Tomas's absence? Thanks!