### PR TITLE
LPS-61981

### DIFF
--- a/modules/portal/portal-ldap/src/main/java/com/liferay/portal/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/portal/portal-ldap/src/main/java/com/liferay/portal/ldap/internal/DefaultPortalLDAP.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.log.LogUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.Props;
@@ -383,6 +384,13 @@ public class DefaultPortalLDAP implements PortalLDAP {
 
 				return ldapServerConfiguration.ldapServerId();
 			}
+		}
+
+		if (!ListUtil.isEmpty(ldapServerConfigurations)) {
+			LDAPServerConfiguration ldapServerConfiguration =
+				ldapServerConfigurations.get(0);
+
+			return ldapServerConfiguration.ldapServerId();
 		}
 
 		return LDAPConstants.SYSTEM_DEFAULT;

--- a/modules/portal/portal-ldap/src/main/java/com/liferay/portal/ldap/internal/configuration/LDAPServerConfigurationProviderImpl.java
+++ b/modules/portal/portal-ldap/src/main/java/com/liferay/portal/ldap/internal/configuration/LDAPServerConfigurationProviderImpl.java
@@ -172,7 +172,9 @@ public class LDAPServerConfigurationProviderImpl
 
 		Configuration configuration = configurations.get(ldapServerId);
 
-		if (configuration == null) {
+		if ((configuration == null) &&
+			!MapUtil.isEmpty(defaultCompanyConfigurations)) {
+
 			configuration = defaultCompanyConfigurations.get(
 				LDAPConstants.SYSTEM_DEFAULT);
 		}
@@ -235,7 +237,7 @@ public class LDAPServerConfigurationProviderImpl
 		}
 
 		List<Dictionary<String, Object>> configurationsProperties =
-			new ArrayList<>(configurations.size());
+			new ArrayList<>();
 
 		if (MapUtil.isEmpty(configurations) && useDefault) {
 			configurationsProperties.add(


### PR DESCRIPTION
For the latter change, the NPE stemmed from a potentially empty (null, really) configuration retrieved from line 176. This was the most elegant way to fix it without introducing more confusing if/else or early return logic, though I understand there might be some additional overhead in not declaring an initial capacity.