### PR TITLE
LPS-61518 When "Display Site Facet" is unchecked, Search portlet results are restricted to current site starting from second search

### DIFF
--- a/modules/apps/search/search-web/src/main/java/com/liferay/search/web/constants/SearchPortletParams.java
+++ b/modules/apps/search/search-web/src/main/java/com/liferay/search/web/constants/SearchPortletParams.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.search.web.constants;
+
+/**
+ * @author André de Oliveira
+ */
+public class SearchPortletParams {
+
+	public static final String EVERYTHING = "everything";
+
+	public static final String FORMAT = "format";
+
+	public static final String GROUP_ID = "groupId";
+
+	public static final String KEYWORDS = "keywords";
+
+	public static final String SCOPE = "scope";
+
+	public static final String THIS_SITE = "this-site";
+
+}

--- a/modules/apps/search/search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
+++ b/modules/apps/search/search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
@@ -17,6 +17,14 @@
 <%@ include file="/facets/init.jsp" %>
 
 <%
+if (Validator.isNull(fieldParam)) {
+	String scopeParam = ParamUtil.getString(request, SearchPortletParams.SCOPE);
+
+	SearchDisplayContext.Scope scope = searchDisplayContext.getScope(scopeParam);
+
+	fieldParam = String.valueOf(scope.getGroupId());
+}
+
 if (termCollectors.isEmpty()) {
 %>
 

--- a/modules/apps/search/search-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/search/search-web/src/main/resources/META-INF/resources/init.jsp
@@ -92,6 +92,7 @@ page import="com.liferay.portlet.asset.service.permission.AssetCategoryPermissio
 page import="com.liferay.search.facet.SearchFacet" %><%@
 page import="com.liferay.search.facet.util.SearchFacetTracker" %><%@
 page import="com.liferay.search.web.constants.SearchPortletKeys" %><%@
+page import="com.liferay.search.web.constants.SearchPortletParams" %><%@
 page import="com.liferay.search.web.display.context.SearchDisplayContext" %><%@
 page import="com.liferay.search.web.facet.AssetEntriesSearchFacet" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %><%@

--- a/modules/apps/search/search-web/src/main/resources/META-INF/resources/search.jsp
+++ b/modules/apps/search/search-web/src/main/resources/META-INF/resources/search.jsp
@@ -23,11 +23,15 @@ if (Validator.isNotNull(redirect)) {
 	portletDisplay.setURLBack(redirect);
 }
 
-long groupId = ParamUtil.getLong(request, "groupId");
+long groupId = ParamUtil.getLong(request, SearchPortletParams.GROUP_ID);
 
-String keywords = ParamUtil.getString(request, "keywords");
+String keywords = ParamUtil.getString(request, SearchPortletParams.KEYWORDS);
 
-String format = ParamUtil.getString(request, "format");
+String format = ParamUtil.getString(request, SearchPortletParams.FORMAT);
+
+String scopeParam = ParamUtil.getString(request, SearchPortletParams.SCOPE);
+
+SearchDisplayContext.Scope scope = searchDisplayContext.getScope(scopeParam);
 
 PortletURL portletURL = PortletURLUtil.getCurrent(renderRequest, renderResponse);
 
@@ -51,6 +55,7 @@ request.setAttribute("search.jsp-returnToFullPageURL", portletDisplay.getURLBack
 
 	<aui:fieldset id="searchContainer">
 		<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" inlineField="<%= true %>" label="" name="keywords" size="30" title="search" value="<%= HtmlUtil.escape(keywords) %>" />
+		<aui:input name="scope" type="hidden" value="<%= scope.getScope() %>" />
 
 		<aui:field-wrapper inlineField="<%= true %>">
 			<aui:button icon="icon-search" onClick='<%= renderResponse.getNamespace() + "search();" %>' value="search" />

--- a/modules/apps/search/search-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/search/search-web/src/main/resources/META-INF/resources/view.jsp
@@ -17,9 +17,17 @@
 <%@ include file="/init.jsp" %>
 
 <%
-long groupId = ParamUtil.getLong(request, "groupId");
+long groupId = ParamUtil.getLong(request, SearchPortletParams.GROUP_ID);
 
-String keywords = ParamUtil.getString(request, "keywords");
+String keywords = ParamUtil.getString(request, SearchPortletParams.KEYWORDS);
+
+String scopeParam = ParamUtil.getString(request, SearchPortletParams.SCOPE);
+
+SearchDisplayContext.Preferences preferences = searchDisplayContext.getPreferences();
+
+SearchDisplayContext.Scope scope = searchDisplayContext.getScope(scopeParam);
+
+boolean scopeEverything = (groupId == 0);
 
 PortletURL portletURL = renderResponse.createRenderURL();
 
@@ -44,25 +52,17 @@ pageContext.setAttribute("portletURL", portletURL);
 		<liferay-ui:quick-access-entry label="skip-to-search" onClick="<%= taglibOnClick %>" />
 
 		<c:choose>
-			<c:when test='<%= Validator.equals(searchDisplayContext.getSearchScope(), "let-the-user-choose") %>'>
-				<aui:select cssClass="search-select" inlineField="<%= true %>" label="" name="groupId" title="scope">
-
-					<%
-					Group group = themeDisplay.getScopeGroup();
-					%>
-
-					<c:if test="<%= !group.isStagingGroup() %>">
-						<aui:option label="everything" selected="<%= (groupId == 0) %>" value="0" />
+			<c:when test="<%= preferences.isScopeLetTheUserChoose() %>">
+				<aui:select cssClass="search-select" inlineField="<%= true %>" label="" name="scope" title="scope">
+					<c:if test="<%= preferences.isScopeEverythingAvailable() %>">
+						<aui:option label="everything" selected="<%= scopeEverything %>" value="everything" />
 					</c:if>
 
-					<aui:option label="this-site" selected="<%= (groupId != 0) %>" value="<%= group.getGroupId() %>" />
+					<aui:option label="this-site" selected="<%= !scopeEverything %>" value="this-site" />
 				</aui:select>
 			</c:when>
-			<c:when test='<%= Validator.equals(searchDisplayContext.getSearchScope(), "everything") %>'>
-				<aui:input name="groupId" type="hidden" value="0" />
-			</c:when>
 			<c:otherwise>
-				<aui:input name="groupId" type="hidden" value="<%= themeDisplay.getScopeGroupId() %>" />
+				<aui:input name="scope" type="hidden" value="<%= scope.getScope() %>" />
 			</c:otherwise>
 		</c:choose>
 

--- a/portal-service/src/com/liferay/portal/kernel/search/SearchContextFactory.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/SearchContextFactory.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.search;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.theme.ThemeDisplay;
@@ -67,6 +68,20 @@ public class SearchContextFactory {
 				else {
 					attributes.put(name, values);
 				}
+			}
+		}
+
+		if (!parameters.containsKey("groupId")) {
+			String[] scope = parameters.get("scope");
+
+			if (scope != null) {
+				String groupId = "0";
+
+				if (Validator.equals( scope[0], "this-site")) {
+					groupId = String.valueOf(themeDisplay.getScopeGroupId());
+				}
+
+				attributes.put("groupId", groupId);
 			}
 		}
 


### PR DESCRIPTION
Thanks @cleydyr for helping us realize that rather than a problem in Search infrastructure, the "search twice" effect was a user interface problem after all :smile: