### PR TITLE
LPS-63019 SCOPE_INDIVIDUAL regressions after LPS-47464

### DIFF
--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/service.xml
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/service.xml
@@ -131,6 +131,7 @@
 		<reference package-path="com.liferay.mobile.device.rules" entity="MDRRule" />
 		<reference package-path="com.liferay.mobile.device.rules" entity="MDRRuleGroupInstance" />
 		<reference package-path="com.liferay.portal" entity="Group" />
+		<reference package-path="com.liferay.portal" entity="Resource" />
 		<reference package-path="com.liferay.portal" entity="SystemEvent" />
 		<reference package-path="com.liferay.portal" entity="User" />
 	</entity>
@@ -190,6 +191,7 @@
 		<reference package-path="com.liferay.portal" entity="ClassName" />
 		<reference package-path="com.liferay.portal" entity="Layout" />
 		<reference package-path="com.liferay.portal" entity="LayoutSet" />
+		<reference package-path="com.liferay.portal" entity="Resource" />
 		<reference package-path="com.liferay.portal" entity="SystemEvent" />
 		<reference package-path="com.liferay.portal" entity="User" />
 	</entity>

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupInstanceLocalServiceBaseImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupInstanceLocalServiceBaseImpl.java
@@ -729,6 +729,25 @@ public abstract class MDRRuleGroupInstanceLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the system event local service.
 	 *
 	 * @return the system event local service
@@ -883,6 +902,8 @@ public abstract class MDRRuleGroupInstanceLocalServiceBaseImpl
 	protected com.liferay.portal.kernel.service.LayoutSetLocalService layoutSetLocalService;
 	@ServiceReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SystemEventLocalService.class)
 	protected com.liferay.portal.kernel.service.SystemEventLocalService systemEventLocalService;
 	@ServiceReference(type = SystemEventPersistence.class)

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupInstanceServiceBaseImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupInstanceServiceBaseImpl.java
@@ -439,6 +439,25 @@ public abstract class MDRRuleGroupInstanceServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the system event local service.
 	 *
 	 * @return the system event local service
@@ -620,6 +639,8 @@ public abstract class MDRRuleGroupInstanceServiceBaseImpl
 	protected com.liferay.portal.kernel.service.LayoutSetService layoutSetService;
 	@ServiceReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SystemEventLocalService.class)
 	protected com.liferay.portal.kernel.service.SystemEventLocalService systemEventLocalService;
 	@ServiceReference(type = SystemEventPersistence.class)

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupLocalServiceBaseImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupLocalServiceBaseImpl.java
@@ -585,6 +585,25 @@ public abstract class MDRRuleGroupLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the system event local service.
 	 *
 	 * @return the system event local service
@@ -765,6 +784,8 @@ public abstract class MDRRuleGroupLocalServiceBaseImpl
 	protected com.liferay.portal.kernel.service.GroupLocalService groupLocalService;
 	@ServiceReference(type = GroupPersistence.class)
 	protected GroupPersistence groupPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SystemEventLocalService.class)
 	protected com.liferay.portal.kernel.service.SystemEventLocalService systemEventLocalService;
 	@ServiceReference(type = SystemEventPersistence.class)

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupServiceBaseImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupServiceBaseImpl.java
@@ -263,6 +263,25 @@ public abstract class MDRRuleGroupServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the system event local service.
 	 *
 	 * @return the system event local service
@@ -483,6 +502,8 @@ public abstract class MDRRuleGroupServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.kernel.service.GroupService groupService;
 	@ServiceReference(type = GroupPersistence.class)
 	protected GroupPersistence groupPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SystemEventLocalService.class)
 	protected com.liferay.portal.kernel.service.SystemEventLocalService systemEventLocalService;
 	@ServiceReference(type = SystemEventPersistence.class)

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupInstanceLocalServiceImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupInstanceLocalServiceImpl.java
@@ -66,6 +66,11 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 		ruleGroupInstance.setRuleGroupId(ruleGroupId);
 		ruleGroupInstance.setPriority(priority);
 
+		// Resources
+
+		resourceLocalService.addModelResources(
+			ruleGroupInstance, serviceContext);
+
 		return updateMDRRuleGroupInstance(ruleGroupInstance);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupLocalServiceImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupLocalServiceImpl.java
@@ -67,6 +67,10 @@ public class MDRRuleGroupLocalServiceImpl
 		ruleGroup.setNameMap(nameMap);
 		ruleGroup.setDescriptionMap(descriptionMap);
 
+		// Resources
+
+		resourceLocalService.addModelResources(ruleGroup, serviceContext);
+
 		return updateMDRRuleGroup(ruleGroup);
 	}
 

--- a/modules/apps/shopping/shopping-service/service.xml
+++ b/modules/apps/shopping/shopping-service/service.xml
@@ -395,6 +395,7 @@
 
 		<reference package-path="com.liferay.mail" entity="Mail" />
 		<reference package-path="com.liferay.portal" entity="Company" />
+		<reference package-path="com.liferay.portal" entity="Resource" />
 		<reference package-path="com.liferay.portal" entity="Subscription" />
 		<reference package-path="com.liferay.portal" entity="User" />
 		<reference package-path="com.liferay.shopping" entity="ShoppingItem" />

--- a/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/base/ShoppingOrderLocalServiceBaseImpl.java
+++ b/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/base/ShoppingOrderLocalServiceBaseImpl.java
@@ -432,6 +432,25 @@ public abstract class ShoppingOrderLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the subscription local service.
 	 *
 	 * @return the subscription local service
@@ -702,6 +721,8 @@ public abstract class ShoppingOrderLocalServiceBaseImpl
 	protected com.liferay.portal.kernel.service.CompanyLocalService companyLocalService;
 	@ServiceReference(type = CompanyPersistence.class)
 	protected CompanyPersistence companyPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SubscriptionLocalService.class)
 	protected com.liferay.portal.kernel.service.SubscriptionLocalService subscriptionLocalService;
 	@ServiceReference(type = SubscriptionPersistence.class)

--- a/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/base/ShoppingOrderServiceBaseImpl.java
+++ b/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/base/ShoppingOrderServiceBaseImpl.java
@@ -229,6 +229,25 @@ public abstract class ShoppingOrderServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the subscription local service.
 	 *
 	 * @return the subscription local service
@@ -539,6 +558,8 @@ public abstract class ShoppingOrderServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.kernel.service.CompanyService companyService;
 	@ServiceReference(type = CompanyPersistence.class)
 	protected CompanyPersistence companyPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SubscriptionLocalService.class)
 	protected com.liferay.portal.kernel.service.SubscriptionLocalService subscriptionLocalService;
 	@ServiceReference(type = SubscriptionPersistence.class)

--- a/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/impl/ShoppingOrderLocalServiceImpl.java
+++ b/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/impl/ShoppingOrderLocalServiceImpl.java
@@ -147,6 +147,13 @@ public class ShoppingOrderLocalServiceImpl
 				order.getUserName());
 		}
 
+		// Resources
+
+		resourceLocalService.addResources(
+			order.getCompanyId(), order.getGroupId(), order.getUserId(),
+			ShoppingOrder.class.getName(), order.getOrderId(), false, true,
+			false);
+
 		return order;
 	}
 

--- a/modules/apps/shopping/shopping-service/src/main/resources/META-INF/resource-actions/default.xml
+++ b/modules/apps/shopping/shopping-service/src/main/resources/META-INF/resource-actions/default.xml
@@ -102,12 +102,8 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>VIEW</action-key>
-			</site-member-defaults>
-			<guest-defaults>
-				<action-key>VIEW</action-key>
-			</guest-defaults>
+			<site-member-defaults />
+			<guest-defaults />
 			<guest-unsupported>
 				<action-key>VIEW</action-key>
 			</guest-unsupported>

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -95,19 +95,19 @@ PortalPreferences portalPreferences = PortletPreferencesFactoryUtil.getPortalPre
 
 boolean filterManageableOrganizations = true;
 
-if (permissionChecker.hasPermission(scopeGroupId, User.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+if (permissionChecker.hasPermission(scopeGroupId, User.class.getName(), User.class.getName(), ActionKeys.VIEW)) {
 	filterManageableOrganizations = false;
 }
 
 String portletId = PortletProviderUtil.getPortletId(PortalMyAccountApplicationType.MyAccount.CLASS_NAME, PortletProvider.Action.VIEW);
 
-if (portletName.equals(portletId) || permissionChecker.hasPermission(scopeGroupId, Organization.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+if (portletName.equals(portletId) || permissionChecker.hasPermission(scopeGroupId, Organization.class.getName(), Organization.class.getName(), ActionKeys.VIEW)) {
 	filterManageableOrganizations = false;
 }
 
 boolean filterManageableUserGroups = true;
 
-if (portletName.equals(portletId) || permissionChecker.hasPermission(scopeGroupId, UserGroup.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+if (portletName.equals(portletId) || permissionChecker.hasPermission(scopeGroupId, UserGroup.class.getName(), UserGroup.class.getName(), ActionKeys.VIEW)) {
 	filterManageableUserGroups = false;
 }
 %>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_assignments.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_assignments.jsp
@@ -80,7 +80,7 @@ renderResponse.setTitle(organization.getName());
 		if (tabs2.equals("current")) {
 			userParams.put("usersOrgs", Long.valueOf(organization.getOrganizationId()));
 		}
-		else if (PropsValues.ORGANIZATIONS_ASSIGNMENT_STRICT && !permissionChecker.isCompanyAdmin() && !permissionChecker.hasPermission(scopeGroupId, User.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+		else if (PropsValues.ORGANIZATIONS_ASSIGNMENT_STRICT && !permissionChecker.isCompanyAdmin() && !permissionChecker.hasPermission(scopeGroupId, User.class.getName(), User.class.getName(), ActionKeys.VIEW)) {
 			userParams.put("usersOrgsTree", user.getOrganizations(true));
 		}
 		%>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -201,7 +201,7 @@ boolean filterManageableGroups = true;
 
 boolean filterManageableOrganizations = true;
 
-if (permissionChecker.hasPermission(0, Organization.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+if (permissionChecker.hasPermission(0, Organization.class.getName(), Organization.class.getName(), ActionKeys.VIEW)) {
 	filterManageableOrganizations = false;
 }
 

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.Team;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -49,7 +48,6 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.TeamLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPrototypePermissionUtil;
 import com.liferay.portal.kernel.service.permission.LayoutSetPrototypePermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
@@ -883,14 +881,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			Group group = GroupLocalServiceUtil.getGroup(groupId);
 
 			companyId = group.getCompanyId();
-		}
-		else if (name.equals(User.class.getName())) {
-			User user = UserLocalServiceUtil.fetchUser(
-				GetterUtil.getLong(primKey));
-
-			if (user != null) {
-				companyId = user.getCompanyId();
-			}
 		}
 
 		try {

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -867,6 +867,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		stopWatch.start();
 
+		if (isOmniadmin()) {
+			return true;
+		}
+
+		if (name.equals(Organization.class.getName())) {
+			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
+				return true;
+			}
+		}
+
 		long companyId = user.getCompanyId();
 
 		if (groupId > 0) {
@@ -880,29 +890,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			if (user != null) {
 				companyId = user.getCompanyId();
-			}
-		}
-
-		boolean hasLayoutManagerPermission = true;
-
-		// Check if the layout manager has permission to do this action for the
-		// current portlet
-
-		if (Validator.isNotNull(name) && Validator.isNotNull(primKey) &&
-			primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
-
-			hasLayoutManagerPermission =
-				PortletPermissionUtil.hasLayoutManagerPermission(
-					name, actionId);
-		}
-
-		if (isOmniadmin()) {
-			return true;
-		}
-
-		if (name.equals(Organization.class.getName())) {
-			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
-				return true;
 			}
 		}
 
@@ -930,8 +917,23 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			return true;
 		}
 
-		if (isGroupAdminImpl(groupId) && hasLayoutManagerPermission) {
-			return true;
+		if (isGroupAdminImpl(groupId)) {
+			boolean hasLayoutManagerPermission = true;
+
+			// Check if the layout manager has permission to do this action for
+			// the current portlet
+
+			if (Validator.isNotNull(name) && Validator.isNotNull(primKey) &&
+				primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+
+				hasLayoutManagerPermission =
+					PortletPermissionUtil.hasLayoutManagerPermission(
+						name, actionId);
+			}
+
+			if (hasLayoutManagerPermission) {
+				return true;
+			}
 		}
 
 		return false;

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.security.permission;
 
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermissionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -816,6 +817,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 				defaultUserId, groupId, resources, actionId,
 				getGuestUserRoleIds());
 		}
+		catch (MissingIndividualScopeResourcePermissionException misrpe) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Somebody is trying to circumvent permission framework " +
+						"or there is a bug in permission framework caller",
+					misrpe);
+			}
+
+			return false;
+		}
 		catch (Exception e) {
 			_log.error(e, e);
 
@@ -885,7 +896,7 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					name, actionId);
 		}
 
-		if (isCompanyAdminImpl(companyId)) {
+		if (isOmniadmin()) {
 			return true;
 		}
 
@@ -894,12 +905,36 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 				return true;
 			}
 		}
-		else if (isGroupAdminImpl(groupId) && hasLayoutManagerPermission) {
+
+		try {
+			boolean hasPermission = doCheckPermission(
+				companyId, groupId, name, primKey, roleIds, actionId,
+				stopWatch);
+
+			if (hasPermission) {
+				return true;
+			}
+		}
+		catch (MissingIndividualScopeResourcePermissionException misrpe) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Somebody is trying to circumvent permission framework " +
+						"or there is a bug in permission framework caller",
+					misrpe);
+			}
+
+			return false;
+		}
+
+		if (isCompanyAdminImpl(companyId)) {
 			return true;
 		}
 
-		return doCheckPermission(
-			companyId, groupId, name, primKey, roleIds, actionId, stopWatch);
+		if (isGroupAdminImpl(groupId) && hasLayoutManagerPermission) {
+			return true;
+		}
+
+		return false;
 	}
 
 	protected boolean isCompanyAdminImpl(long companyId) throws Exception {

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermiss
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.GroupedModel;
@@ -692,6 +693,28 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		}
 	}
 
+	protected String fixLegacyPrimaryKey(
+		long companyId, String name, String primKey) {
+
+		if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
+			(primKey.equals(String.valueOf(companyId)) &&
+			 !name.equals(Company.class.getName()))) {
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Legacy primary key " + primKey + " was used for " +
+						"permission checking of " + name + " in company " +
+						companyId + ". Please use " + name + " as the " +
+						"primary key.",
+					new Exception());
+			}
+
+			return name;
+		}
+
+		return primKey;
+	}
+
 	/**
 	 * Returns representations of the resource at each scope level.
 	 *
@@ -798,8 +821,11 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		long companyId = user.getCompanyId();
 
-		List<Resource> resources = getResources(
-			companyId, groupId, name, primKey, actionId);
+		if (groupId > 0) {
+			Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+			companyId = group.getCompanyId();
+		}
 
 		try {
 			if (ResourceBlockLocalServiceUtil.isSupported(name)) {
@@ -810,6 +836,11 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					name, GetterUtil.getLong(primKey), actionId,
 					resourceBlockIdsBag);
 			}
+
+			primKey = fixLegacyPrimaryKey(companyId, name, primKey);
+
+			List<Resource> resources = getResources(
+				companyId, groupId, name, primKey, actionId);
 
 			return ResourceLocalServiceUtil.hasUserPermissions(
 				defaultUserId, groupId, resources, actionId,
@@ -882,6 +913,8 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			companyId = group.getCompanyId();
 		}
+
+		primKey = fixLegacyPrimaryKey(companyId, name, primKey);
 
 		try {
 			boolean hasPermission = doCheckPermission(

--- a/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
@@ -536,7 +536,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 		}
 
 		if (permissionChecker.hasPermission(
-				checkGroupId, className, 0, ActionKeys.VIEW)) {
+				checkGroupId, className, className, ActionKeys.VIEW)) {
 
 			return sql;
 		}

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -719,6 +719,7 @@
 		<reference package-path="com.liferay.portal" entity="LayoutRevision" />
 		<reference package-path="com.liferay.portal" entity="LayoutSetBranch" />
 		<reference package-path="com.liferay.portal" entity="RecentLayoutBranch" />
+		<reference package-path="com.liferay.portal" entity="Resource" />
 		<reference package-path="com.liferay.portal" entity="User" />
 	</entity>
 	<entity name="LayoutFriendlyURL" uuid="true" local-service="true" remote-service="false">

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -3358,6 +3358,7 @@
 		<exception>LayoutSetVirtualHost</exception>
 		<exception>LayoutType</exception>
 		<exception>MembershipRequestComments</exception>
+		<exception>MissingIndividualScopeResourcePermission</exception>
 		<exception>OldServiceComponent</exception>
 		<exception>OrganizationId</exception>
 		<exception>OrganizationName</exception>

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutBranchLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutBranchLocalServiceBaseImpl.java
@@ -487,6 +487,25 @@ public abstract class LayoutBranchLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the user local service.
 	 *
 	 * @return the user local service
@@ -611,6 +630,8 @@ public abstract class LayoutBranchLocalServiceBaseImpl
 	protected com.liferay.portal.kernel.service.RecentLayoutBranchLocalService recentLayoutBranchLocalService;
 	@BeanReference(type = RecentLayoutBranchPersistence.class)
 	protected RecentLayoutBranchPersistence recentLayoutBranchPersistence;
+	@BeanReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@BeanReference(type = com.liferay.portal.kernel.service.UserLocalService.class)
 	protected com.liferay.portal.kernel.service.UserLocalService userLocalService;
 	@BeanReference(type = UserPersistence.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutBranchServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutBranchServiceBaseImpl.java
@@ -282,6 +282,25 @@ public abstract class LayoutBranchServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the user local service.
 	 *
 	 * @return the user local service
@@ -427,6 +446,8 @@ public abstract class LayoutBranchServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.kernel.service.RecentLayoutBranchLocalService recentLayoutBranchLocalService;
 	@BeanReference(type = RecentLayoutBranchPersistence.class)
 	protected RecentLayoutBranchPersistence recentLayoutBranchPersistence;
+	@BeanReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@BeanReference(type = com.liferay.portal.kernel.service.UserLocalService.class)
 	protected com.liferay.portal.kernel.service.UserLocalService userLocalService;
 	@BeanReference(type = com.liferay.portal.kernel.service.UserService.class)

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
@@ -67,6 +67,13 @@ public class LayoutBranchLocalServiceImpl
 
 		layoutBranchPersistence.update(layoutBranch);
 
+		// Resources
+
+		resourceLocalService.addResources(
+			layoutBranch.getCompanyId(), layoutBranch.getGroupId(),
+			layoutBranch.getUserId(), LayoutBranch.class.getName(),
+			layoutBranch.getLayoutBranchId(), false, true, false);
+
 		StagingUtil.setRecentLayoutBranchId(
 			user, layoutBranch.getLayoutSetBranchId(), layoutBranch.getPlid(),
 			layoutBranch.getLayoutBranchId());

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
@@ -78,11 +78,9 @@ public class LayoutPrototypeLocalServiceImpl
 
 		// Resources
 
-		if (userId > 0) {
-			resourceLocalService.addResources(
-				companyId, 0, userId, LayoutPrototype.class.getName(),
-				layoutPrototype.getLayoutPrototypeId(), false, false, false);
-		}
+		resourceLocalService.addResources(
+			companyId, 0, userId, LayoutPrototype.class.getName(),
+			layoutPrototype.getLayoutPrototypeId(), false, true, false);
 
 		// Group
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
@@ -84,12 +84,9 @@ public class LayoutSetPrototypeLocalServiceImpl
 
 		// Resources
 
-		if (userId > 0) {
-			resourceLocalService.addResources(
-				companyId, 0, userId, LayoutSetPrototype.class.getName(),
-				layoutSetPrototype.getLayoutSetPrototypeId(), false, false,
-				false);
-		}
+		resourceLocalService.addResources(
+			companyId, 0, userId, LayoutSetPrototype.class.getName(),
+			layoutSetPrototype.getLayoutSetPrototypeId(), false, true, false);
 
 		// Group
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
@@ -105,11 +105,15 @@ public class PasswordPolicyLocalServiceImpl
 
 		// Resources
 
-		if (!user.isDefaultUser()) {
-			resourceLocalService.addResources(
-				user.getCompanyId(), 0, userId, PasswordPolicy.class.getName(),
-				passwordPolicy.getPasswordPolicyId(), false, false, false);
+		long ownerId = userId;
+
+		if (user.isDefaultUser()) {
+			ownerId = 0;
 		}
+
+		resourceLocalService.addResources(
+			user.getCompanyId(), 0, ownerId, PasswordPolicy.class.getName(),
+			passwordPolicy.getPasswordPolicyId(), false, false, false);
 
 		return passwordPolicy;
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.Type;
+import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermissionException;
 import com.liferay.portal.kernel.exception.NoSuchResourcePermissionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -690,7 +691,10 @@ public class ResourcePermissionLocalServiceImpl
 				individualResource.getScope(),
 				individualResource.getPrimKey()) < 1) {
 
-			return false;
+			throw new MissingIndividualScopeResourcePermissionException(
+				"There is no " + individualResource.getName() +
+					" with primary key " + individualResource.getPrimKey() +
+						" and companyId " + individualResource.getCompanyId());
 		}
 
 		// Iterate the list of resources in reverse order to test permissions

--- a/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
@@ -211,7 +211,7 @@ public class GroupPermissionImpl
 		PermissionChecker permissionChecker, String actionId) {
 
 		return permissionChecker.hasPermission(
-			0, Group.class.getName(), 0, actionId);
+			0, Group.class.getName(), Group.class.getName(), actionId);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -94,6 +94,10 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 
 		assetTagPersistence.update(tag);
 
+		// Resources
+
+		resourceLocalService.addModelResources(tag, serviceContext);
+
 		return tag;
 	}
 

--- a/portal-impl/src/com/liferay/portlet/social/service/permission/SocialActivityPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/permission/SocialActivityPermissionImpl.java
@@ -49,7 +49,7 @@ public class SocialActivityPermissionImpl implements SocialActivityPermission {
 		}
 
 		if (permissionChecker.hasPermission(
-				groupId, getPortletId(), 0, actionId)) {
+				groupId, getPortletId(), getPortletId(), actionId)) {
 
 			return true;
 		}

--- a/portal-service/src/com/liferay/portal/kernel/exception/MissingIndividualScopeResourcePermissionException.java
+++ b/portal-service/src/com/liferay/portal/kernel/exception/MissingIndividualScopeResourcePermissionException.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.exception;
+
+import aQute.bnd.annotation.ProviderType;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+@ProviderType
+public class MissingIndividualScopeResourcePermissionException
+	extends PortalException {
+
+	public MissingIndividualScopeResourcePermissionException() {
+	}
+
+	public MissingIndividualScopeResourcePermissionException(String msg) {
+		super(msg);
+	}
+
+	public MissingIndividualScopeResourcePermissionException(
+		String msg, Throwable cause) {
+
+		super(msg, cause);
+	}
+
+	public MissingIndividualScopeResourcePermissionException(Throwable cause) {
+		super(cause);
+	}
+
+}


### PR DESCRIPTION
Hi Mike,

here are 3 sub-tickets from https://issues.liferay.com/browse/LPS-63019. Maybe it would be faster to send Brian 3 PRs instead of one.

https://issues.liferay.com/browse/LPS-63020
The core issue here is that company admin is still able to access cross-company resources. When ResourcePermissionLSI returns false on missing SCOPE_INDIVIDUAL resource permission, AdvancedPermissionChecker still can return `true` if the user is company admin of own company.

So I'm throwing an exception when we try to check permissions on resources that doesn't exist and return false.


https://issues.liferay.com/browse/LPS-63021
On several places we want to check model-resource permissions without having any existing model. Seems we use the logic for some time so I don't want to remove it and rather create "default" model with primaryKey==name that we can use for this kind of checks.

https://issues.liferay.com/browse/LPS-63022
Developers seem still not understand that they need to create resources for entities that should be used by permission framework. So I fixed that and create resource for every entity we use in `permissionChecker.hasPermission(..., entity.class.getName(), ...)`

Before these commits the parts of code only worked for company admin / omniadmin. Any other users with (for example) manually defined permissions were ignored.

Thanks.