### PR TITLE
LPS-59837 AssetTagNames facet and exact phrase searches - pull 1 of 2

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayDocumentTypeFactory.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayDocumentTypeFactory.java
@@ -34,17 +34,14 @@ import org.elasticsearch.common.settings.Settings;
  */
 public class LiferayDocumentTypeFactory implements TypeMappingsHelper {
 
-	public LiferayDocumentTypeFactory(
-		String indexName, IndicesAdminClient indicesAdminClient) {
-
-		_indexName = indexName;
+	public LiferayDocumentTypeFactory(IndicesAdminClient indicesAdminClient) {
 		_indicesAdminClient = indicesAdminClient;
 	}
 
 	@Override
-	public void addTypeMappings(String source) {
+	public void addTypeMappings(String indexName, String source) {
 		PutMappingRequestBuilder putMappingRequestBuilder =
-			_indicesAdminClient.preparePutMapping(_indexName);
+			_indicesAdminClient.preparePutMapping(indexName);
 
 		putMappingRequestBuilder.setSource(source);
 		putMappingRequestBuilder.setType(
@@ -60,7 +57,7 @@ public class LiferayDocumentTypeFactory implements TypeMappingsHelper {
 		}
 	}
 
-	public void createOptionalDefaultTypeMappings() {
+	public void createOptionalDefaultTypeMappings(String indexName) {
 		String name = StringUtil.replace(
 			LiferayTypeMappingsConstants.
 				LIFERAY_DOCUMENT_TYPE_MAPPING_FILE_NAME,
@@ -69,7 +66,7 @@ public class LiferayDocumentTypeFactory implements TypeMappingsHelper {
 		String optionalDefaultTypeMappings = ResourceUtil.getResourceAsString(
 			getClass(), name);
 
-		addTypeMappings(optionalDefaultTypeMappings);
+		addTypeMappings(indexName, optionalDefaultTypeMappings);
 	}
 
 	public void createRequiredDefaultAnalyzers(Settings.Builder builder) {
@@ -95,7 +92,6 @@ public class LiferayDocumentTypeFactory implements TypeMappingsHelper {
 	private static final Log _log = LogFactoryUtil.getLog(
 		LiferayDocumentTypeFactory.class);
 
-	private final String _indexName;
 	private final IndicesAdminClient _indicesAdminClient;
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/settings/TypeMappingsHelper.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/settings/TypeMappingsHelper.java
@@ -19,6 +19,6 @@ package com.liferay.portal.search.elasticsearch.settings;
  */
 public interface TypeMappingsHelper {
 
-	public void addTypeMappings(String source);
+	public void addTypeMappings(String indexName, String source);
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchIndexingFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchIndexingFixture.java
@@ -24,7 +24,7 @@ import com.liferay.portal.search.elasticsearch.internal.connection.Elasticsearch
 import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.IndexName;
 import com.liferay.portal.search.elasticsearch.internal.connection.IndexCreationHelper;
 import com.liferay.portal.search.elasticsearch.internal.document.DefaultElasticsearchDocumentFactory;
-import com.liferay.portal.search.elasticsearch.internal.facet.DateRangeFacetProcessor;
+import com.liferay.portal.search.elasticsearch.internal.facet.DefaultFacetProcessor;
 import com.liferay.portal.search.elasticsearch.internal.filter.BooleanFilterTranslatorImpl;
 import com.liferay.portal.search.elasticsearch.internal.filter.DateRangeTermFilterTranslatorImpl;
 import com.liferay.portal.search.elasticsearch.internal.filter.ElasticsearchFilterTranslator;
@@ -178,7 +178,7 @@ public class ElasticsearchIndexingFixture implements IndexingFixture {
 			{
 				elasticsearchConnectionManager =
 					elasticsearchConnectionManager1;
-				facetProcessor = new DateRangeFacetProcessor();
+				facetProcessor = new DefaultFacetProcessor();
 				filterTranslator = createElasticsearchFilterTranslator();
 				groupByTranslator = new DefaultGroupByTranslator();
 				indexNameBuilder = indexNameBuilder1;

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/connection/ElasticsearchFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/connection/ElasticsearchFixture.java
@@ -98,7 +98,7 @@ public class ElasticsearchFixture {
 
 		createIndexRequestBuilder.get();
 
-		indexCreationHelper.whenIndexCreated();
+		indexCreationHelper.whenIndexCreated(name);
 
 		return new Index(indexName);
 	}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/connection/IndexCreationHelper.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/connection/IndexCreationHelper.java
@@ -26,6 +26,6 @@ public interface IndexCreationHelper {
 
 	public void contributeIndexSettings(Settings.Builder builder);
 
-	public void whenIndexCreated();
+	public void whenIndexCreated(String indexName);
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/connection/LiferayIndexCreationHelper.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/connection/LiferayIndexCreationHelper.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.search.elasticsearch.internal.connection;
 
-import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.IndexName;
 import com.liferay.portal.search.elasticsearch.internal.index.LiferayDocumentTypeFactory;
 
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
@@ -26,11 +25,9 @@ import org.elasticsearch.common.settings.Settings;
  */
 public class LiferayIndexCreationHelper implements IndexCreationHelper {
 
-	public LiferayIndexCreationHelper(
-		IndicesAdminClient indicesAdminClient, IndexName indexName) {
-
+	public LiferayIndexCreationHelper(IndicesAdminClient indicesAdminClient) {
 		_liferayDocumentTypeFactory = new LiferayDocumentTypeFactory(
-			indexName.getName(), indicesAdminClient);
+			indicesAdminClient);
 	}
 
 	@Override
@@ -47,8 +44,9 @@ public class LiferayIndexCreationHelper implements IndexCreationHelper {
 	}
 
 	@Override
-	public void whenIndexCreated() {
-		_liferayDocumentTypeFactory.createOptionalDefaultTypeMappings();
+	public void whenIndexCreated(String indexName) {
+		_liferayDocumentTypeFactory.createOptionalDefaultTypeMappings(
+			indexName);
 	}
 
 	private final LiferayDocumentTypeFactory _liferayDocumentTypeFactory;

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/groupby/GroupByTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/groupby/GroupByTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.elasticsearch.internal.groupby;
 
 import com.liferay.portal.search.elasticsearch.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.unit.test.BaseIndexingTestCase;
 import com.liferay.portal.search.unit.test.IndexingFixture;
 import com.liferay.portal.search.unit.test.groupby.BaseGroupByTestCase;
 
@@ -44,11 +45,9 @@ public class GroupByTest extends BaseGroupByTestCase {
 	}
 
 	@Override
-	protected IndexingFixture createIndexingFixture(String indexName)
-		throws Exception {
-
+	protected IndexingFixture createIndexingFixture() {
 		return new ElasticsearchIndexingFixture(
-			GroupByTest.class.getSimpleName(), indexName);
+			GroupByTest.class.getSimpleName(), BaseIndexingTestCase.COMPANY_ID);
 	}
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/CompanyIndexFactoryTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/CompanyIndexFactoryTest.java
@@ -186,6 +186,7 @@ public class CompanyIndexFactoryTest {
 				@Override
 				public void contribute(TypeMappingsHelper typeMappingsHelper) {
 					typeMappingsHelper.addTypeMappings(
+						getTestIndexName(),
 						replaceAnalyzer(mappings, "brazilian"));
 				}
 

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayTypeMappingsTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayTypeMappingsTest.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.Index;
 import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.IndexName;
-import com.liferay.portal.search.elasticsearch.internal.connection.IndexCreationHelper;
 import com.liferay.portal.search.elasticsearch.internal.connection.LiferayIndexCreationHelper;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -88,14 +87,10 @@ public class LiferayTypeMappingsTest {
 	}
 
 	protected Index createIndex() {
-		IndexName indexName = new IndexName(testName.getMethodName());
-
-		IndexCreationHelper indexCreationHelper =
-			new LiferayIndexCreationHelper(
-				_elasticsearchFixture.getIndicesAdminClient(), indexName);
-
 		return _elasticsearchFixture.createIndex(
-			indexName, indexCreationHelper);
+			new IndexName(testName.getMethodName()),
+			new LiferayIndexCreationHelper(
+				_elasticsearchFixture.getIndicesAdminClient()));
 	}
 
 	private ElasticsearchFixture _elasticsearchFixture;

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/stats/StatisticsTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/stats/StatisticsTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.elasticsearch.internal.stats;
 
 import com.liferay.portal.search.elasticsearch.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.unit.test.BaseIndexingTestCase;
 import com.liferay.portal.search.unit.test.IndexingFixture;
 import com.liferay.portal.search.unit.test.stats.BaseStatisticsTestCase;
 
@@ -32,11 +33,10 @@ public class StatisticsTest extends BaseStatisticsTestCase {
 	}
 
 	@Override
-	protected IndexingFixture createIndexingFixture(String indexName)
-		throws Exception {
-
+	protected IndexingFixture createIndexingFixture() {
 		return new ElasticsearchIndexingFixture(
-			StatisticsTest.class.getSimpleName(), indexName);
+			StatisticsTest.class.getSimpleName(),
+			BaseIndexingTestCase.COMPANY_ID);
 	}
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-solr/build.gradle
+++ b/modules/apps/foundation/portal-search/portal-search-solr/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 	provided group: "org.apache.lucene", name: "lucene-queryparser", version: "5.2.1"
 	provided group: "org.apache.lucene", name: "lucene-sandbox", version: "5.2.1"
 	provided group: "org.apache.lucene", name: "lucene-suggest", version: "5.2.1"
-	provided group: "org.apache.solr", name: "solr-core", transitive: false, version: "5.2.1"
 	provided group: "org.apache.solr", name: "solr-solrj", version: "5.2.1"
 	provided group: "org.apache.zookeeper", name: "zookeeper", version: "3.4.6"
 	provided group: "org.codehaus.woodstox", name: "stax2-api", version: "3.1.4"

--- a/modules/apps/foundation/portal-search/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
+++ b/modules/apps/foundation/portal-search/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
@@ -540,15 +540,17 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 		Collection<String> fieldNames = solrDocument.getFieldNames();
 
 		for (String fieldName : fieldNames) {
-			Collection<Object> fieldValues = solrDocument.getFieldValues(
-				fieldName);
+			if (!fieldName.equals(_VERSION_FIELD)) {
+				Collection<Object> fieldValues = solrDocument.getFieldValues(
+					fieldName);
 
-			Field field = new Field(
-				fieldName,
-				ArrayUtil.toStringArray(
-					fieldValues.toArray(new Object[fieldValues.size()])));
+				Field field = new Field(
+					fieldName,
+					ArrayUtil.toStringArray(
+						fieldValues.toArray(new Object[fieldValues.size()])));
 
-			document.add(field);
+				document.add(field);
+			}
 		}
 
 		populateUID(document, queryConfig);
@@ -704,6 +706,8 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 			hits.addStatsResults(statsResults);
 		}
 	}
+
+	private static final String _VERSION_FIELD = "_version_";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SolrIndexSearcher.class);

--- a/modules/apps/foundation/portal-search/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/SolrIndexingFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/SolrIndexingFixture.java
@@ -20,7 +20,7 @@ import com.liferay.portal.search.solr.connection.SolrClientManager;
 import com.liferay.portal.search.solr.connection.TestSolrClientManager;
 import com.liferay.portal.search.solr.document.SolrUpdateDocumentCommand;
 import com.liferay.portal.search.solr.internal.document.DefaultSolrDocumentFactory;
-import com.liferay.portal.search.solr.internal.facet.DateRangeFacetProcessor;
+import com.liferay.portal.search.solr.internal.facet.DefaultFacetProcessor;
 import com.liferay.portal.search.solr.internal.filter.BooleanFilterTranslatorImpl;
 import com.liferay.portal.search.solr.internal.filter.DateRangeTermFilterTranslatorImpl;
 import com.liferay.portal.search.solr.internal.filter.ExistsFilterTranslatorImpl;
@@ -61,7 +61,7 @@ import java.util.Map;
  */
 public class SolrIndexingFixture implements IndexingFixture {
 
-	public SolrIndexingFixture() throws Exception {
+	public SolrIndexingFixture() {
 		_properties = createSolrConfigurationProperties();
 	}
 
@@ -145,7 +145,7 @@ public class SolrIndexingFixture implements IndexingFixture {
 
 		return new SolrIndexSearcher() {
 			{
-				setFacetProcessor(new DateRangeFacetProcessor());
+				setFacetProcessor(new DefaultFacetProcessor());
 				setFilterTranslator(createSolrFilterTranslator());
 				setGroupByTranslator(new DefaultGroupByTranslator());
 				setQueryTranslator(createSolrQueryTranslator());

--- a/modules/apps/foundation/portal-search/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/groupby/GroupByTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/groupby/GroupByTest.java
@@ -44,9 +44,7 @@ public class GroupByTest extends BaseGroupByTestCase {
 	}
 
 	@Override
-	protected IndexingFixture createIndexingFixture(String indexName)
-		throws Exception {
-
+	protected IndexingFixture createIndexingFixture() {
 		return new SolrIndexingFixture();
 	}
 

--- a/modules/apps/foundation/portal-search/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/stats/StatisticsTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/stats/StatisticsTest.java
@@ -32,9 +32,7 @@ public class StatisticsTest extends BaseStatisticsTestCase {
 	}
 
 	@Override
-	protected IndexingFixture createIndexingFixture(String indexName)
-		throws Exception {
-
+	protected IndexingFixture createIndexingFixture() {
 		return new SolrIndexingFixture();
 	}
 

--- a/modules/apps/web-experience/journal/journal-test/bnd.bnd
+++ b/modules/apps/web-experience/journal/journal-test/bnd.bnd
@@ -6,9 +6,9 @@ Import-Package:\
 	\
 	!org.junit.experimental.theories,\
 	*
+Include-Resource:\
+	test-classes/integration,\
+	@lib/com.liferay.util.java.jar!/com/liferay/util/xml/XMLUtil.class
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Web Content
 -include: ../../app.bnd
--liferay-includeresource:\
-	test-classes/integration,\
-	@com.liferay.util.java-*.jar!/com/liferay/util/xml/XMLUtil.class

--- a/modules/apps/web-experience/journal/journal-test/build.gradle
+++ b/modules/apps/web-experience/journal/journal-test/build.gradle
@@ -1,3 +1,7 @@
+copyLibs {
+	enabled = true
+}
+
 dependencies {
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 

--- a/portal-impl/test/integration/com/liferay/portal/kernel/search/FacetedSearcherTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/kernel/search/FacetedSearcherTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.search;
 
+import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
@@ -57,6 +58,7 @@ public class FacetedSearcherTest {
 
 		_userSearchFixture.setUp();
 
+		_assetTags = _userSearchFixture.getAssetTags();
 		_groups = _userSearchFixture.getGroups();
 		_users = _userSearchFixture.getUsers();
 	}
@@ -136,6 +138,9 @@ public class FacetedSearcherTest {
 
 		return searchContext;
 	}
+
+	@DeleteAfterTestRun
+	private List<AssetTag> _assetTags;
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;

--- a/portal-impl/test/integration/com/liferay/portal/kernel/search/UserSearchFixture.java
+++ b/portal-impl/test/integration/com/liferay/portal/kernel/search/UserSearchFixture.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.search;
 
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -38,16 +40,25 @@ public class UserSearchFixture {
 		return group;
 	}
 
-	public void addUser(Group group, String tag) throws Exception {
+	public void addUser(Group group, String... tags) throws Exception {
 		User user = UserTestUtil.addUser(group.getGroupId());
 
 		_users.add(user);
 
 		ServiceContext serviceContext = getServiceContext(group);
 
-		serviceContext.setAssetTagNames(new String[] {tag});
+		serviceContext.setAssetTagNames(tags);
 
 		UserTestUtil.updateUser(user, serviceContext);
+
+		List<AssetTag> assetTags = AssetTagLocalServiceUtil.getTags(
+			user.getModelClassName(), user.getPrimaryKey());
+
+		_assetTags.addAll(assetTags);
+	}
+
+	public List<AssetTag> getAssetTags() {
+		return _assetTags;
 	}
 
 	public List<Group> getGroups() {
@@ -71,6 +82,7 @@ public class UserSearchFixture {
 			group.getGroupId(), TestPropsValues.getUserId());
 	}
 
+	private final List<AssetTag> _assetTags = new ArrayList<>();
 	private final List<Group> _groups = new ArrayList<>();
 	private final List<User> _users = new ArrayList<>();
 

--- a/portal-impl/test/integration/com/liferay/portal/kernel/search/facet/MultiValueFacetTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/kernel/search/facet/MultiValueFacetTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.search.facet;
 
+import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.FacetedSearcher;
@@ -57,6 +58,7 @@ public class MultiValueFacetTest {
 
 		_userSearchFixture.setUp();
 
+		_assetTags = _userSearchFixture.getAssetTags();
 		_groups = _userSearchFixture.getGroups();
 		_users = _userSearchFixture.getUsers();
 	}
@@ -124,6 +126,9 @@ public class MultiValueFacetTest {
 
 		return searchContext;
 	}
+
+	@DeleteAfterTestRun
+	private List<AssetTag> _assetTags;
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;

--- a/portal-impl/test/integration/com/liferay/portal/kernel/search/facet/ScopeFacetTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/kernel/search/facet/ScopeFacetTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.search.facet;
 
+import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.FacetedSearcher;
@@ -60,6 +61,7 @@ public class ScopeFacetTest {
 
 		_userSearchFixture.setUp();
 
+		_assetTags = _userSearchFixture.getAssetTags();
 		_groups = _userSearchFixture.getGroups();
 		_users = _userSearchFixture.getUsers();
 	}
@@ -223,6 +225,9 @@ public class ScopeFacetTest {
 
 		return searchContext;
 	}
+
+	@DeleteAfterTestRun
+	private List<AssetTag> _assetTags;
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;

--- a/portal-test/src/com/liferay/portal/search/unit/test/BaseIndexingTestCase.java
+++ b/portal-test/src/com/liferay/portal/search/unit/test/BaseIndexingTestCase.java
@@ -46,7 +46,7 @@ public abstract class BaseIndexingTestCase {
 	public void setUp() throws Exception {
 		_documentFixture.setUp();
 
-		_indexingFixture = createIndexingFixture(String.valueOf(COMPANY_ID));
+		_indexingFixture = createIndexingFixture();
 
 		Assume.assumeTrue(_indexingFixture.isSearchEngineAvailable());
 
@@ -107,8 +107,7 @@ public abstract class BaseIndexingTestCase {
 		_indexWriter.addDocument(createSearchContext(), document);
 	}
 
-	protected abstract IndexingFixture createIndexingFixture(String indexName)
-		throws Exception;
+	protected abstract IndexingFixture createIndexingFixture() throws Exception;
 
 	protected Hits search(SearchContext searchContext) throws Exception {
 		Query query = new TermQueryImpl(


### PR DESCRIPTION
First pull in a series of two.

This is some [yak shaving](https://lonesysadmin.net/2011/09/26/yak-shaving/) indirectly required for the actual [LPS-59837](https://issues.liferay.com/browse/LPS-59837) fix, already complete and ready to follow in a second pull as soon as this gets in master. Too big for a single pull, splitting should make it easier to review.

Sorry for the changes to portal-kernel... even more sorry for even more changes coming up in the next pull. When this issue is over, I'll move Facet implementations out of portal-kernel and into portal-search to prevent further headaches.

