### PR TITLE
LPS-65030 kernel changes

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/mobile/device/Device.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/mobile/device/Device.java
@@ -30,8 +30,16 @@ public interface Device extends Serializable {
 
 	public String getBrowserVersion();
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public Map<String, Capability> getCapabilities();
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public String getCapability(String name);
 
 	public String getModel();

--- a/portal-kernel/src/com/liferay/portal/kernel/mobile/device/DeviceDetectionUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/mobile/device/DeviceDetectionUtil.java
@@ -163,7 +163,7 @@ public class DeviceDetectionUtil {
 
 			String type = (String)serviceReference.getProperty("type");
 
-			if (type.equals("default")) {
+			if (Validator.isNotNull(type) && type.equals("default")) {
 				_defaultDeviceRecognitionProvider = null;
 			}
 			else {

--- a/portal-kernel/src/com/liferay/portal/kernel/mobile/device/DeviceRecognitionProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/mobile/device/DeviceRecognitionProvider.java
@@ -28,6 +28,10 @@ public interface DeviceRecognitionProvider {
 
 	public void reload() throws Exception;
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public void setDeviceCapabilityFilter(
 		DeviceCapabilityFilter deviceCapabilityFilter);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/mobile/device/KnownDevices.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/mobile/device/KnownDevices.java
@@ -27,6 +27,10 @@ public interface KnownDevices {
 
 	public Set<VersionableName> getBrowsers();
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public Map<Capability, Set<String>> getDeviceIds();
 
 	public Set<VersionableName> getOperatingSystems();


### PR DESCRIPTION
Hey Mike,

These are the methods that we found to be specific to WURFL and thus not needed in our 51 degrees implementation. We also found a bug in DeviceDetectionUtil that would cause a NPE at times. 

As an update for the actual 51 Degrees implementation, we're just about done cleaning up some areas and are moving on to some final testing to make sure the Mobile Device Rules are still working as they should. 

Thanks,
Brian