### PR TITLE
LPS-66076 Add default support for importing all portlet preferences

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-resources-importer/build.gradle
+++ b/modules/apps/web-experience/export-import/export-import-resources-importer/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.wiki.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	provided group: "commons-collections", name: "commons-collections", version: "3.2.1"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"

--- a/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/constants/ResourcesImporterConstants.java
+++ b/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/constants/ResourcesImporterConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.resources.importer.constants;
+
+/**
+ * @author Brian Greenwald
+ */
+public class ResourcesImporterConstants {
+
+	public static final String DEFAULT = "default";
+
+}

--- a/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/portlet/preferences/DefaultPortletPreferencesTranslator.java
+++ b/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/portlet/preferences/DefaultPortletPreferencesTranslator.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.resources.importer.internal.portlet.preferences;
+
+import com.liferay.exportimport.resources.importer.constants.ResourcesImporterConstants;
+import com.liferay.exportimport.resources.importer.portlet.preferences.PortletPreferencesTranslator;
+import com.liferay.portal.kernel.json.JSONObject;
+
+import javax.portlet.PortletException;
+import javax.portlet.PortletPreferences;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Brian Greenwald
+ */
+@Component(
+	immediate = true,
+	property = "portlet.preferences.translator.portlet.id=" + ResourcesImporterConstants.DEFAULT
+)
+public class DefaultPortletPreferencesTranslator
+	implements PortletPreferencesTranslator {
+
+	@Override
+	public void translate(
+			JSONObject portletPreferencesJSONObject, String key,
+			PortletPreferences portletPreferences)
+		throws PortletException {
+
+		String value = portletPreferencesJSONObject.getString(key);
+
+		portletPreferences.setValue(key, value);
+	}
+
+}

--- a/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/util/FileSystemImporter.java
+++ b/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/util/FileSystemImporter.java
@@ -38,6 +38,7 @@ import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
 import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.dynamic.data.mapping.util.DDMUtil;
 import com.liferay.dynamic.data.mapping.util.DDMXML;
+import com.liferay.exportimport.resources.importer.constants.ResourcesImporterConstants;
 import com.liferay.exportimport.resources.importer.portlet.preferences.PortletPreferencesTranslator;
 import com.liferay.journal.configuration.JournalServiceConfigurationValues;
 import com.liferay.journal.model.JournalArticle;
@@ -115,6 +116,8 @@ import java.util.regex.Pattern;
 
 import javax.portlet.PortletPreferences;
 
+import org.apache.commons.collections.map.DefaultedMap;
+
 /**
  * @author Ryan Park
  * @author Raymond Augé
@@ -163,7 +166,13 @@ public class FileSystemImporter extends BaseImporter {
 		this.portal = portal;
 		this.portletPreferencesFactory = portletPreferencesFactory;
 		this.portletPreferencesLocalService = portletPreferencesLocalService;
-		this.portletPreferencesTranslators = portletPreferencesTranslators;
+
+		PortletPreferencesTranslator defaultPortletPreferencesTranslator =
+			portletPreferencesTranslators.get(
+				ResourcesImporterConstants.DEFAULT);
+		this.portletPreferencesTranslators = DefaultedMap.decorate(
+			portletPreferencesTranslators, defaultPortletPreferencesTranslator);
+
 		this.repositoryLocalService = repositoryLocalService;
 		this.saxReader = saxReader;
 		this.themeLocalService = themeLocalService;


### PR DESCRIPTION
Hey @mhan810 ,

I revised the previous pull I had sent you to the following. Let me know if there's anything I should change. I basically added a default translator that's able to translate basic portlet preferences for portlets that do not otherwise have a discrete translator.

The other PR I sent you yesterday, [LPS-66084](https://github.com/mhan810/liferay-portal/pull/1198) will allow us to add custom translators in our own modules that need extra logic to successfully translate.

Thanks!
Brian

@igorarouca
@danielkocsis