### PR TITLE
LPS-59977 Query Builders per field

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarSearcherTest.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarSearcherTest.java
@@ -124,16 +124,16 @@ public class CalendarSearcherTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		assertSearch("\"Two Three\" Five", 1);
-		assertSearch("\"Two Three\" Nine", 1);
-		assertSearch("\"Two  Four\" Five", 1);
+		assertSearch("\"Two Three\" Nine", 0);
+		assertSearch("\"Two  Four\" Five", 0);
 		assertSearch("\"Two  Four\" Nine", 0);
 		assertSearch("Three \"Five Six\"", 1);
-		assertSearch("Zero  \"Five Six\"", 1);
-		assertSearch("Three \"Four Six\"", 1);
+		assertSearch("Zero  \"Five Six\"", 0);
+		assertSearch("Three \"Four Six\"", 0);
 		assertSearch("Zero  \"Four Six\"", 0);
 		assertSearch("One  \"Three Four\" Six ", 1);
-		assertSearch("Zero \"Three Four\" Nine", 1);
-		assertSearch("One  \"Three Five\" Six ", 1);
+		assertSearch("Zero \"Three Four\" Nine", 0);
+		assertSearch("One  \"Three Five\" Six ", 0);
 		assertSearch("Zero \"Three Five\" Nine", 0);
 	}
 

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
@@ -188,15 +188,15 @@ public class DDLRecordSearchTest {
 		addRecord(RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		assertSearch("\"Two Three\" Five", 1);
-		assertSearch("\"Two Three\" Nine", 1);
+		assertSearch("\"Two Three\" Nine", 0);
 		assertSearch("\"Two  Four\" Five", 0);
 		assertSearch("\"Two  Four\" Nine", 0);
 		assertSearch("Three \"Five Six\"", 1);
-		assertSearch("Zero  \"Five Six\"", 1);
+		assertSearch("Zero  \"Five Six\"", 0);
 		assertSearch("Three \"Four Six\"", 0);
 		assertSearch("Zero  \"Four Six\"", 0);
 		assertSearch("One  \"Three Four\" Six ", 1);
-		assertSearch("Zero \"Three Four\" Nine", 1);
+		assertSearch("Zero \"Three Four\" Nine", 0);
 		assertSearch("One  \"Three Five\" Six ", 0);
 		assertSearch("Zero \"Three Five\" Nine", 0);
 	}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/document/DefaultElasticsearchDocumentFactory.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/document/DefaultElasticsearchDocumentFactory.java
@@ -102,7 +102,7 @@ public class DefaultElasticsearchDocumentFactory
 			List<String> valuesList = new ArrayList<>(values.length);
 
 			for (String value : values) {
-				if (Validator.isNull(value)) {
+				if (value == null) {
 					continue;
 				}
 

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -809,6 +809,11 @@
 				"store": "yes",
 				"type": "string"
 			},
+			"screenName": {
+				"index": "not_analyzed",
+				"store": "yes",
+				"type": "string"
+			},
 			"size": {
 				"index": "not_analyzed",
 				"store": "yes",

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/document/DefaultElasticsearchDocumentFactoryTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/document/DefaultElasticsearchDocumentFactoryTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.document;
+
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.search.elasticsearch.document.ElasticsearchDocumentFactory;
+import com.liferay.portal.search.unit.test.DocumentFixture;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author André de Oliveira
+ */
+public class DefaultElasticsearchDocumentFactoryTest {
+
+	@Before
+	public void setUp() throws Exception {
+		_documentFixture.setUp();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_documentFixture.tearDown();
+	}
+
+	@Test
+	public void testNull() throws Exception {
+		assertElasticsearchDocument(null, "{}");
+	}
+
+	@Test
+	public void testSpaces() throws Exception {
+		assertElasticsearchDocument(StringPool.SPACE, "{\"field\":\"\"}");
+
+		assertElasticsearchDocument(
+			StringPool.THREE_SPACES, "{\"field\":\"\"}");
+	}
+
+	@Test
+	public void testStringBlank() throws Exception {
+		assertElasticsearchDocument(StringPool.BLANK, "{\"field\":\"\"}");
+	}
+
+	@Test
+	public void testStringNull() throws Exception {
+		assertElasticsearchDocument(StringPool.NULL, "{\"field\":\"null\"}");
+	}
+
+	protected void assertElasticsearchDocument(String value, String json)
+		throws Exception {
+
+		Document document = new DocumentImpl();
+
+		document.addText("field", new String[] {value});
+
+		Assert.assertEquals(
+			json,
+			_elasticsearchDocumentFactory.getElasticsearchDocument(document));
+	}
+
+	private final DocumentFixture _documentFixture = new DocumentFixture();
+	private final ElasticsearchDocumentFactory _elasticsearchDocumentFactory =
+		new DefaultElasticsearchDocumentFactory();
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/analysis/FieldQueryBuilderFactory.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/analysis/FieldQueryBuilderFactory.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.analysis;
+
+/**
+ * @author Rodrigo Paulino
+ */
+public interface FieldQueryBuilderFactory {
+
+	public QueryBuilder getQueryBuilder(String fieldName);
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/analysis/QueryBuilder.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/analysis/QueryBuilder.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.analysis;
+
+import com.liferay.portal.kernel.search.Query;
+
+/**
+ * @author Rodrigo Paulino
+ */
+public interface QueryBuilder {
+
+	public Query build(String fieldName, String keywords);
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/configuration/QueryPreProcessConfiguration.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/configuration/QueryPreProcessConfiguration.java
@@ -32,7 +32,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface QueryPreProcessConfiguration {
 
 	@Meta.AD(
-		deflt = "assetCategoryTitles?(_.+)?|assetTagNames|emailAddress|firstName|lastName|license|middleName|name|path|screenName|tag|treePath|userName",
+		deflt = "assetCategoryTitles?(_.+)?|assetTagNames|emailAddress|license|path|screenName|tag|treePath|userName",
 		required = false
 	)
 	public String[] fieldNamePatterns();

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/DescriptionQueryBuilder.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/DescriptionQueryBuilder.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.analysis;
+
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.search.analysis.KeywordTokenizer;
+import com.liferay.portal.search.analysis.QueryBuilder;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author André de Oliveira
+ * @author Rodrigo Paulino
+ */
+@Component(
+	immediate = true, property = {"exact.match.boost=2.0", "proximity.slop=50"},
+	service = DescriptionQueryBuilder.class
+)
+public class DescriptionQueryBuilder implements QueryBuilder {
+
+	@Override
+	public Query build(String field, String keywords) {
+		FullTextQueryBuilder builder = new FullTextQueryBuilder(
+			keywordTokenizer);
+
+		builder.setExactMatchBoost(_exactMatchBoost);
+		builder.setProximitySlop(_proximitySlop);
+
+		return builder.build(field, keywords);
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_exactMatchBoost = GetterUtil.getFloat(
+			properties.get("exact.match.boost"), _exactMatchBoost);
+
+		_proximitySlop = GetterUtil.getInteger(
+			properties.get("proximity.slop"), _proximitySlop);
+	}
+
+	@Reference
+	protected KeywordTokenizer keywordTokenizer;
+
+	private volatile float _exactMatchBoost = 2.0f;
+	private volatile int _proximitySlop = 50;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FieldQueryBuilderFactoryImpl.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.analysis;
+
+import com.liferay.portal.kernel.search.query.QueryPreProcessConfiguration;
+import com.liferay.portal.kernel.util.CharPool;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.analysis.FieldQueryBuilderFactory;
+import com.liferay.portal.search.analysis.QueryBuilder;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author André de Oliveira
+ * @author Rodrigo Paulino
+ */
+@Component(
+	immediate = true,
+	property = {"description.fields=description", "title.fields=title"},
+	service = FieldQueryBuilderFactory.class
+)
+public class FieldQueryBuilderFactoryImpl implements FieldQueryBuilderFactory {
+
+	@Override
+	public QueryBuilder getQueryBuilder(String field) {
+		if (queryPreProcessConfiguration.isSubstringSearchAlways(field)) {
+			return substringQueryBuilder;
+		}
+
+		if (_descriptionFields.contains(field)) {
+			return descriptionQueryBuilder;
+		}
+
+		if (_titleFields.contains(field)) {
+			return titleQueryBuilder;
+		}
+
+		return null;
+	}
+
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_descriptionFields = getFields(properties, "description.fields");
+		_titleFields = getFields(properties, "title.fields");
+	}
+
+	protected Collection<String> getFields(
+		Map<String, Object> properties, String key) {
+
+		String[] values = StringUtil.split(
+			GetterUtil.getString(properties.get(key)), CharPool.PIPE);
+
+		return new HashSet<>(Arrays.asList(values));
+	}
+
+	@Reference
+	protected DescriptionQueryBuilder descriptionQueryBuilder;
+
+	@Reference
+	protected QueryPreProcessConfiguration queryPreProcessConfiguration;
+
+	@Reference
+	protected SubstringQueryBuilder substringQueryBuilder;
+
+	@Reference
+	protected TitleQueryBuilder titleQueryBuilder;
+
+	private volatile Collection<String> _descriptionFields =
+		Collections.singleton("description");
+	private volatile Collection<String> _titleFields = Collections.singleton(
+		"title");
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FullTextQueryBuilder.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/FullTextQueryBuilder.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.analysis;
+
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.MatchQuery;
+import com.liferay.portal.kernel.util.CharPool;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.analysis.KeywordTokenizer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author André de Oliveira
+ */
+public class FullTextQueryBuilder {
+
+	public FullTextQueryBuilder(KeywordTokenizer keywordTokenizer) {
+		_keywordTokenizer = keywordTokenizer;
+	}
+
+	public Query build(String field, String keywords) {
+		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
+
+		List<String> tokens = _keywordTokenizer.tokenize(keywords);
+
+		List<String> phrases = new ArrayList<>(tokens.size());
+		List<String> words = new ArrayList<>(tokens.size());
+
+		for (String token : tokens) {
+			if (StringUtil.startsWith(token, CharPool.QUOTE)) {
+				phrases.add(StringUtil.unquote(token));
+			}
+			else {
+				words.add(token);
+			}
+		}
+
+		for (String phrase : phrases) {
+			booleanQueryImpl.add(
+				createPhraseQuery(field, phrase), BooleanClauseOccur.MUST);
+		}
+
+		if (!words.isEmpty()) {
+			addSentenceQueries(
+				field, StringUtil.merge(words, StringPool.SPACE),
+				booleanQueryImpl);
+		}
+
+		booleanQueryImpl.add(
+			createExactMatchQuery(field, keywords), BooleanClauseOccur.SHOULD);
+
+		return booleanQueryImpl;
+	}
+
+	public void setAutocomplete(boolean autocomplete) {
+		_autocomplete = autocomplete;
+	}
+
+	public void setExactMatchBoost(float exactMatchBoost) {
+		_exactMatchBoost = exactMatchBoost;
+	}
+
+	public void setProximitySlop(int proximitySlop) {
+		_proximitySlop = proximitySlop;
+	}
+
+	protected void addSentenceQueries(
+		String field, String sentence, BooleanQueryImpl booleanQueryImpl) {
+
+		booleanQueryImpl.add(
+			createMandatoryQuery(field, sentence), BooleanClauseOccur.MUST);
+
+		if (_proximitySlop != null) {
+			booleanQueryImpl.add(
+				createProximityQuery(field, sentence),
+				BooleanClauseOccur.SHOULD);
+		}
+	}
+
+	protected Query createAutocompleteQuery(String field, String value) {
+		PhraseQueryBuilder builder = new PhraseQueryBuilder();
+
+		builder.setPrefix(true);
+
+		return builder.build(field, value);
+	}
+
+	protected Query createExactMatchQuery(String field, String keywords) {
+		PhraseQueryBuilder builder = new PhraseQueryBuilder();
+
+		builder.setBoost(_exactMatchBoost);
+
+		return builder.build(field, keywords);
+	}
+
+	protected Query createMandatoryQuery(String field, String sentence) {
+		Query matchQuery = createMatchQuery(field, sentence);
+
+		if (!_autocomplete) {
+			return matchQuery;
+		}
+
+		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
+
+		booleanQueryImpl.add(matchQuery, BooleanClauseOccur.SHOULD);
+
+		booleanQueryImpl.add(
+			createAutocompleteQuery(field, sentence),
+			BooleanClauseOccur.SHOULD);
+
+		return booleanQueryImpl;
+	}
+
+	protected Query createMatchQuery(String field, String value) {
+		return new MatchQuery(field, value);
+	}
+
+	protected Query createPhraseQuery(String field, String phrase) {
+		PhraseQueryBuilder builder = new PhraseQueryBuilder();
+
+		builder.setTrailingStarAware(true);
+
+		return builder.build(field, phrase);
+	}
+
+	protected Query createProximityQuery(String field, String value) {
+		PhraseQueryBuilder builder = new PhraseQueryBuilder();
+
+		builder.setSlop(_proximitySlop);
+
+		return builder.build(field, value);
+	}
+
+	private boolean _autocomplete;
+	private float _exactMatchBoost;
+	private final KeywordTokenizer _keywordTokenizer;
+	private Integer _proximitySlop;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/PhraseQueryBuilder.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/PhraseQueryBuilder.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.analysis;
+
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.generic.MatchQuery;
+import com.liferay.portal.kernel.util.StringPool;
+
+/**
+ * @author André de Oliveira
+ */
+public class PhraseQueryBuilder {
+
+	public Query build(String field, String value) {
+		MatchQuery matchQuery = new MatchQuery(field, value);
+
+		MatchQuery.Type type = MatchQuery.Type.PHRASE;
+
+		if (_prefix) {
+			type = MatchQuery.Type.PHRASE_PREFIX;
+		}
+
+		if (_trailingStarAware && value.endsWith(StringPool.STAR)) {
+			value = value.substring(0, value.length() - 1);
+
+			type = MatchQuery.Type.PHRASE_PREFIX;
+		}
+
+		matchQuery.setType(type);
+
+		if (_boost != null) {
+			matchQuery.setBoost(_boost);
+		}
+
+		if (_slop != null) {
+			matchQuery.setSlop(_slop);
+		}
+
+		return matchQuery;
+	}
+
+	public void setBoost(float boost) {
+		_boost = boost;
+	}
+
+	public void setPrefix(boolean prefix) {
+		_prefix = prefix;
+	}
+
+	public void setSlop(int slop) {
+		_slop = slop;
+	}
+
+	public void setTrailingStarAware(boolean trailingStarAware) {
+		_trailingStarAware = trailingStarAware;
+	}
+
+	private Float _boost;
+	private boolean _prefix;
+	private Integer _slop;
+	private boolean _trailingStarAware;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/SimpleKeywordTokenizer.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/SimpleKeywordTokenizer.java
@@ -28,10 +28,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Michael C. Han
  */
-@Component(
-	immediate = true, property = {"mode=default"},
-	service = KeywordTokenizer.class
-)
+@Component(immediate = true, service = KeywordTokenizer.class)
 public class SimpleKeywordTokenizer implements KeywordTokenizer {
 
 	@Override

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/SimpleKeywordTokenizer.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/SimpleKeywordTokenizer.java
@@ -15,11 +15,13 @@
 package com.liferay.portal.search.internal.analysis;
 
 import com.liferay.portal.kernel.util.CharPool;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.analysis.KeywordTokenizer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -65,6 +67,14 @@ public class SimpleKeywordTokenizer implements KeywordTokenizer {
 		return tokens;
 	}
 
+	protected String[] split(String keyword) {
+		if (Objects.equals(keyword, StringPool.NULL)) {
+			return new String[] {keyword};
+		}
+
+		return StringUtil.split(keyword, CharPool.SPACE);
+	}
+
 	protected void tokenize(
 		String keyword, List<String> tokens, int start, int end) {
 
@@ -106,7 +116,7 @@ public class SimpleKeywordTokenizer implements KeywordTokenizer {
 			return;
 		}
 
-		start = keyword.indexOf(CharPool.QUOTE, end + 1);
+		start = keyword.indexOf(CharPool.QUOTE);
 
 		end = keyword.indexOf(CharPool.QUOTE, start + 1);
 
@@ -114,7 +124,7 @@ public class SimpleKeywordTokenizer implements KeywordTokenizer {
 	}
 
 	protected void tokenizeBySpace(String keyword, List<String> tokens) {
-		String[] keywordTokens = StringUtil.split(keyword, CharPool.SPACE);
+		String[] keywordTokens = split(keyword);
 
 		for (String keywordToken : keywordTokens) {
 			keyword = keywordToken.trim();

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/SubstringQueryBuilder.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/SubstringQueryBuilder.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.analysis;
+
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.generic.QueryTermImpl;
+import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
+import com.liferay.portal.kernel.util.CharPool;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.analysis.KeywordTokenizer;
+import com.liferay.portal.search.analysis.QueryBuilder;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author André de Oliveira
+ * @author Rodrigo Paulino
+ */
+@Component(immediate = true, service = SubstringQueryBuilder.class)
+public class SubstringQueryBuilder implements QueryBuilder {
+
+	@Override
+	public Query build(String field, String keywords) {
+		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
+
+		List<String> tokens = keywordTokenizer.tokenize(keywords);
+
+		for (String token : tokens) {
+			booleanQueryImpl.add(
+				createQuery(field, token), BooleanClauseOccur.SHOULD);
+		}
+
+		return booleanQueryImpl;
+	}
+
+	protected Query createQuery(String field, String value) {
+		if (StringUtil.startsWith(value, CharPool.QUOTE)) {
+			value = StringUtil.unquote(value);
+		}
+
+		value = StringUtil.replace(value, CharPool.PERCENT, StringPool.BLANK);
+
+		if (value.isEmpty()) {
+			value = StringPool.STAR;
+		}
+		else {
+			value = StringUtil.quote(
+				StringUtil.toLowerCase(value), StringPool.STAR);
+		}
+
+		return new WildcardQueryImpl(new QueryTermImpl(field, value));
+	}
+
+	@Reference
+	protected KeywordTokenizer keywordTokenizer;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/TitleQueryBuilder.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/analysis/TitleQueryBuilder.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.analysis;
+
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.search.analysis.KeywordTokenizer;
+import com.liferay.portal.search.analysis.QueryBuilder;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author André de Oliveira
+ * @author Rodrigo Paulino
+ */
+@Component(
+	immediate = true, property = {"exact.match.boost=2.0"},
+	service = TitleQueryBuilder.class
+)
+public class TitleQueryBuilder implements QueryBuilder {
+
+	@Override
+	public Query build(String field, String keywords) {
+		FullTextQueryBuilder builder = new FullTextQueryBuilder(
+			keywordTokenizer);
+
+		builder.setAutocomplete(true);
+		builder.setExactMatchBoost(_exactMatchBoost);
+
+		return builder.build(field, keywords);
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_exactMatchBoost = GetterUtil.getFloat(
+			properties.get("exact.match.boost"), _exactMatchBoost);
+	}
+
+	@Reference
+	protected KeywordTokenizer keywordTokenizer;
+
+	private volatile float _exactMatchBoost = 2.0f;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/FieldQueryFactoryImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/query/FieldQueryFactoryImpl.java
@@ -14,280 +14,74 @@
 
 package com.liferay.portal.search.internal.query;
 
-import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Query;
-import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
-import com.liferay.portal.kernel.search.generic.MatchQuery;
-import com.liferay.portal.kernel.search.generic.QueryTermImpl;
-import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
 import com.liferay.portal.kernel.search.query.FieldQueryFactory;
-import com.liferay.portal.kernel.search.query.QueryPreProcessConfiguration;
-import com.liferay.portal.kernel.util.CharPool;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.search.analysis.KeywordTokenizer;
+import com.liferay.portal.search.analysis.FieldQueryBuilderFactory;
+import com.liferay.portal.search.analysis.QueryBuilder;
+import com.liferay.portal.search.internal.analysis.TitleQueryBuilder;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.HashSet;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Michael C. Han
  */
-@Component(
-	immediate = true,
-	property = {
-		"full.text.exact.match.boost=2.0", "full.text.proximity.slop=50"
-	},
-	service = FieldQueryFactory.class
-)
+@Component(immediate = true, service = FieldQueryFactory.class)
 public class FieldQueryFactoryImpl implements FieldQueryFactory {
 
 	@Override
 	public Query createQuery(
-		String field, String value, boolean like, boolean splitKeywords) {
+		String fieldName, String keywords, boolean like,
+		boolean splitKeywords) {
 
-		boolean isSubstringSearchAlways = false;
+		QueryBuilder queryBuilder = getQueryBuilder(fieldName);
 
-		if (_queryPreProcessConfiguration != null) {
-			isSubstringSearchAlways =
-				_queryPreProcessConfiguration.isSubstringSearchAlways(field);
-		}
-
-		if (!isSubstringSearchAlways) {
-			return createQueryForFullTextSearch(field, value);
-		}
-
-		KeywordTokenizer keywordTokenizer = getKeywordTokenizer();
-
-		if (!splitKeywords && (keywordTokenizer != null)) {
-			splitKeywords = keywordTokenizer.requiresTokenization(value);
-		}
-
-		if (splitKeywords && (keywordTokenizer != null)) {
-			List<String> tokens = keywordTokenizer.tokenize(value);
-
-			if (tokens.size() == 1) {
-				return createQuery(field, tokens.get(0), like, false);
-			}
-
-			BooleanQueryImpl booleanQuery = new BooleanQueryImpl();
-
-			for (String token : tokens) {
-				Query tokenQuery = createTokenQuery(field, token);
-
-				booleanQuery.add(tokenQuery, BooleanClauseOccur.SHOULD);
-			}
-
-			return booleanQuery;
-		}
-
-		return createTokenQuery(field, value);
-	}
-
-	@Activate
-	@Modified
-	protected void activate(Map<String, Object> properties) {
-		_fullTextExactMatchBoost = GetterUtil.getFloat(
-			properties.get("full.text.exact.match.boost"),
-			_fullTextExactMatchBoost);
-
-		_fullTextProximitySlop = GetterUtil.getInteger(
-			properties.get("full.text.proximity.slop"), _fullTextProximitySlop);
-	}
-
-	protected Query createPhraseMatchQuery(String field, String value) {
-		if (!isPhrase(value)) {
-			return null;
-		}
-
-		value = value.substring(1, value.length() - 1);
-
-		MatchQuery matchQuery = new MatchQuery(field, value);
-
-		if (value.endsWith(StringPool.STAR)) {
-			matchQuery.setType(MatchQuery.Type.PHRASE_PREFIX);
-		}
-		else {
-			matchQuery.setType(MatchQuery.Type.PHRASE);
-		}
-
-		return matchQuery;
-	}
-
-	protected Query createQueryForFullTextExactMatch(
-		String field, String value) {
-
-		MatchQuery matchQuery = new MatchQuery(field, value);
-
-		matchQuery.setType(MatchQuery.Type.PHRASE);
-
-		matchQuery.setBoost(_fullTextExactMatchBoost);
-
-		return matchQuery;
-	}
-
-	protected Query createQueryForFullTextProximity(
-		String field, String value) {
-
-		MatchQuery matchQuery = new MatchQuery(field, value);
-
-		matchQuery.setType(MatchQuery.Type.PHRASE);
-
-		matchQuery.setSlop(_fullTextProximitySlop);
-
-		return matchQuery;
-	}
-
-	protected Query createQueryForFullTextScoring(String field, String value) {
-		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
-
-		booleanQueryImpl.add(
-			new MatchQuery(field, value), BooleanClauseOccur.MUST);
-
-		booleanQueryImpl.add(
-			createQueryForFullTextExactMatch(field, value),
-			BooleanClauseOccur.SHOULD);
-
-		booleanQueryImpl.add(
-			createQueryForFullTextProximity(field, value),
-			BooleanClauseOccur.SHOULD);
-
-		List<String> phrases = getEmbeddedPhrases(value);
-
-		for (String phrase : phrases) {
-			booleanQueryImpl.add(
-				createPhraseMatchQuery(field, phrase), BooleanClauseOccur.MUST);
-		}
-
-		return booleanQueryImpl;
-	}
-
-	protected Query createQueryForFullTextSearch(String field, String value) {
-		Query query = createPhraseMatchQuery(field, value);
-
-		if (query != null) {
-			return query;
-		}
-
-		return createQueryForFullTextScoring(field, value);
-	}
-
-	protected Query createQueryForSubstringSearch(String field, String value) {
-		value = StringUtil.replace(value, CharPool.PERCENT, StringPool.BLANK);
-
-		if (value.length() == 0) {
-			value = StringPool.STAR;
-		}
-		else {
-			value = StringUtil.toLowerCase(value);
-
-			value = StringPool.STAR + value + StringPool.STAR;
-		}
-
-		return new WildcardQueryImpl(new QueryTermImpl(field, value));
-	}
-
-	protected Query createTokenQuery(String field, String value) {
-		Query query = createPhraseMatchQuery(field, value);
-
-		if (query != null) {
-			return query;
-		}
-
-		return createQueryForSubstringSearch(field, value);
-	}
-
-	protected List<String> getEmbeddedPhrases(String value) {
-		KeywordTokenizer keywordTokenizer = getKeywordTokenizer();
-
-		if (keywordTokenizer == null) {
-			return Collections.emptyList();
-		}
-
-		List<String> tokens = keywordTokenizer.tokenize(value);
-
-		List<String> phrases = new ArrayList<>(tokens.size());
-
-		for (String token : tokens) {
-			if (isPhrase(token)) {
-				phrases.add(token);
-			}
-		}
-
-		return phrases;
-	}
-
-	protected KeywordTokenizer getKeywordTokenizer() {
-		if (_keywordTokenizer != null) {
-			return _keywordTokenizer;
-		}
-
-		return _defaultKeywordTokenizer;
-	}
-
-	protected boolean isPhrase(String value) {
-		if (value.startsWith(StringPool.QUOTE) &&
-			value.endsWith(StringPool.QUOTE)) {
-
-			return true;
-		}
-
-		return false;
+		return queryBuilder.build(fieldName, keywords);
 	}
 
 	@Reference(
-		cardinality = ReferenceCardinality.OPTIONAL,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC
 	)
-	protected void setKeywordTokenizer(
-		KeywordTokenizer keywordTokenizer, Map<String, Object> properties) {
+	protected void addFieldQueryBuilderFactory(
+		FieldQueryBuilderFactory fieldQueryBuilderFactory) {
 
-		String mode = (String)properties.get("mode");
-
-		if (Validator.isNotNull(mode) && mode.equals("default")) {
-			_defaultKeywordTokenizer = keywordTokenizer;
-		}
-		else {
-			_keywordTokenizer = keywordTokenizer;
-		}
+		_fieldQueryBuilderFactories.add(fieldQueryBuilderFactory);
 	}
 
-	protected void unsetKeywordTokenizer(
-		KeywordTokenizer keywordTokenizer, Map<String, Object> properties) {
-
-		String mode = (String)properties.get("mode");
-
-		if (Validator.isNotNull(mode) && mode.equals("default")) {
-			_defaultKeywordTokenizer = null;
-		}
-		else {
-			_keywordTokenizer = null;
-		}
+	protected QueryBuilder getDefaultQueryBuilder() {
+		return titleQueryBuilder;
 	}
 
-	private KeywordTokenizer _defaultKeywordTokenizer;
-	private volatile float _fullTextExactMatchBoost = 2.0f;
-	private volatile int _fullTextProximitySlop = 50;
-	private KeywordTokenizer _keywordTokenizer;
+	protected QueryBuilder getQueryBuilder(String fieldName) {
+		for (FieldQueryBuilderFactory fieldQueryBuilderFactory :
+				_fieldQueryBuilderFactories) {
 
-	@Reference(
-		cardinality = ReferenceCardinality.OPTIONAL,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
-	)
-	private volatile QueryPreProcessConfiguration _queryPreProcessConfiguration;
+			QueryBuilder queryBuilder =
+				fieldQueryBuilderFactory.getQueryBuilder(fieldName);
+
+			if (queryBuilder != null) {
+				return queryBuilder;
+			}
+		}
+
+		return getDefaultQueryBuilder();
+	}
+
+	protected void removeFieldQueryBuilderFactory(
+		FieldQueryBuilderFactory fieldQueryBuilderFactory) {
+
+		_fieldQueryBuilderFactories.remove(fieldQueryBuilderFactory);
+	}
+
+	@Reference
+	protected TitleQueryBuilder titleQueryBuilder;
+
+	private final HashSet<FieldQueryBuilderFactory>
+		_fieldQueryBuilderFactories = new HashSet<>();
 
 }

--- a/modules/apps/foundation/portal-search/portal-search/src/main/resources/com/liferay/portal/search/analysis/packageinfo
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/resources/com/liferay/portal/search/analysis/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.1
+version 2.1.0

--- a/modules/apps/foundation/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/analysis/SimpleKeywordTokenizerTest.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/analysis/SimpleKeywordTokenizerTest.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.internal.analysis;
 
+import com.liferay.portal.kernel.util.StringPool;
+
 import java.util.List;
 
 import org.junit.Assert;
@@ -26,86 +28,76 @@ public class SimpleKeywordTokenizerTest {
 
 	@Test
 	public void testRequiresTokenization() {
-		SimpleKeywordTokenizer simpleKeywordTokenizer =
-			new SimpleKeywordTokenizer();
-
-		Assert.assertTrue(
-			simpleKeywordTokenizer.requiresTokenization(
-				"This is a simple test"));
-		Assert.assertTrue(
-			simpleKeywordTokenizer.requiresTokenization(
-				"This \"is a simple\" test"));
-		Assert.assertFalse(
-			simpleKeywordTokenizer.requiresTokenization("\"is a simple\""));
+		Assert.assertTrue(requiresTokenization("This is a simple test"));
+		Assert.assertTrue(requiresTokenization("This \"is a simple\" test"));
+		Assert.assertFalse(requiresTokenization("\"is a simple\""));
 	}
 
 	@Test
 	public void testTokenize() {
-		SimpleKeywordTokenizer simpleKeywordTokenizer =
-			new SimpleKeywordTokenizer();
+		assertTokenize(
+			"This is a simple token test",
+			"[This, is, a, simple, token, test]");
+	}
 
-		List<String> tokens = simpleKeywordTokenizer.tokenize(
-			"This is a simple token test");
+	@Test(expected = NullPointerException.class)
+	public void testTokenizeNull() {
+		simpleKeywordTokenizer.tokenize(null);
+	}
 
-		Assert.assertEquals(6, tokens.size());
-		Assert.assertEquals("This", tokens.get(0));
-		Assert.assertEquals("is", tokens.get(1));
-		Assert.assertEquals("a", tokens.get(2));
-		Assert.assertEquals("simple", tokens.get(3));
-		Assert.assertEquals("token", tokens.get(4));
-		Assert.assertEquals("test", tokens.get(5));
+	@Test
+	public void testTokenizeStringBlank() {
+		assertTokenize(StringPool.BLANK, "[]");
+	}
+
+	@Test
+	public void testTokenizeStringNull() {
+		assertTokenize(StringPool.NULL, "[null]");
 	}
 
 	@Test
 	public void testTokenizeWithQuote() {
-		SimpleKeywordTokenizer simpleKeywordTokenizer =
-			new SimpleKeywordTokenizer();
+		assertTokenize(
+			"This is a \"simple token\" test",
+			"[This, is, a, \"simple token\", test]");
 
-		List<String> tokens = simpleKeywordTokenizer.tokenize(
-			"This is a \"simple token\" test");
+		assertTokenize(
+			"This \"is a\" simple token test",
+			"[This, \"is a\", simple, token, test]");
 
-		Assert.assertEquals(5, tokens.size());
-		Assert.assertEquals("This", tokens.get(0));
-		Assert.assertEquals("is", tokens.get(1));
-		Assert.assertEquals("a", tokens.get(2));
-		Assert.assertEquals("\"simple token\"", tokens.get(3));
-		Assert.assertEquals("test", tokens.get(4));
-
-		List<String> tokens2 = simpleKeywordTokenizer.tokenize(
-			"This \"is a\" simple token test");
-
-		Assert.assertEquals(5, tokens.size());
-		Assert.assertEquals("This", tokens2.get(0));
-		Assert.assertEquals("\"is a\"", tokens2.get(1));
-		Assert.assertEquals("simple", tokens2.get(2));
-		Assert.assertEquals("token", tokens2.get(3));
-		Assert.assertEquals("test", tokens2.get(4));
+		assertTokenize(
+			"\"This is a token test\"", "[\"This is a token test\"]");
 	}
 
 	@Test
 	public void testTokenizeWithQuoteAndMixedSpace() {
-		SimpleKeywordTokenizer simpleKeywordTokenizer =
-			new SimpleKeywordTokenizer();
+		assertTokenize(
+			"This   is  a \"simple token\"   test",
+			"[This, is, a, \"simple token\", test]");
 
-		List<String> tokens = simpleKeywordTokenizer.tokenize(
-			"This   is  a \"simple token\"   test");
-
-		Assert.assertEquals(5, tokens.size());
-		Assert.assertEquals("This", tokens.get(0));
-		Assert.assertEquals("is", tokens.get(1));
-		Assert.assertEquals("a", tokens.get(2));
-		Assert.assertEquals("\"simple token\"", tokens.get(3));
-		Assert.assertEquals("test", tokens.get(4));
-
-		List<String> tokens2 = simpleKeywordTokenizer.tokenize(
-			"This  is a \"simple   token\"  test");
-
-		Assert.assertEquals(5, tokens2.size());
-		Assert.assertEquals("This", tokens2.get(0));
-		Assert.assertEquals("is", tokens2.get(1));
-		Assert.assertEquals("a", tokens2.get(2));
-		Assert.assertEquals("\"simple   token\"", tokens2.get(3));
-		Assert.assertEquals("test", tokens2.get(4));
+		assertTokenize(
+			"This  is a \"simple   token\"  test",
+			"[This, is, a, \"simple   token\", test]");
 	}
+
+	@Test
+	public void testTokenizeWithSeveralQuotes() {
+		assertTokenize(
+			"\"   This is   \"   a   \"   token test   \"",
+			"[\"   This is   \", a, \"   token test   \"]");
+	}
+
+	protected void assertTokenize(String string, String expected) {
+		List<String> tokens = simpleKeywordTokenizer.tokenize(string);
+
+		Assert.assertEquals(expected, tokens.toString());
+	}
+
+	protected boolean requiresTokenization(String string) {
+		return simpleKeywordTokenizer.requiresTokenization(string);
+	}
+
+	protected final SimpleKeywordTokenizer simpleKeywordTokenizer =
+		new SimpleKeywordTokenizer();
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/util/UserIndexerTest.java
@@ -128,12 +128,9 @@ public class UserIndexerTest {
 		addUserNameFields(firstName, lastName, middleName);
 
 		assertHits("firstName", "\"Mary Watson\"", 0);
+		assertHits("firstName", "\"Mary Jane\" Missingword", 0);
 
 		User user = assertSearchOneUser("firstName", "Mary \"Jane Watson\"");
-
-		Assert.assertEquals(firstName, user.getFirstName());
-
-		user = assertSearchOneUser("firstName", "\"Mary Jane\" Trial");
 
 		Assert.assertEquals(firstName, user.getFirstName());
 	}
@@ -237,28 +234,18 @@ public class UserIndexerTest {
 	}
 
 	@Test
-	public void testScreenNamePrefix() throws Exception {
-		addUserScreenName("Open4Life");
-
-		User user = assertSearchOneUser("OPE");
-
-		Assert.assertEquals("open4life", user.getScreenName());
-	}
-
-	@Test
 	public void testScreenNameSubstring() throws Exception {
 		addUserScreenName("Open4Life");
 
-		User user = assertSearchOneUser("4lif");
+		User user = assertSearchOneUser("open lite");
 
 		Assert.assertEquals("open4life", user.getScreenName());
-	}
 
-	@Test
-	public void testScreenNameTwoWords() throws Exception {
-		addUserScreenName("Open4Life");
+		user = assertSearchOneUser("OPE");
 
-		User user = assertSearchOneUser("screenName", "open lite");
+		Assert.assertEquals("open4life", user.getScreenName());
+
+		user = assertSearchOneUser("4lif");
 
 		Assert.assertEquals("open4life", user.getScreenName());
 	}


### PR DESCRIPTION
Query Builders per field, with 3 reference implementations: 

* Title: for short full text fields, with default autocomplete-style prefix match
* Description: for verbose full text fields, with proximity slop
* Substring: for legacy non analyzed fields.

Unit tests kept in a separate branch for now: https://github.com/arboliveira/liferay-portal/tree/LPS-59977-Query-Builders-per-field-WITH-tests  -  That branch can't be merged yet, its last commit is a ugly hack required for 'ant all' to work, otherwise it crashes early on. (Some problem in Gradle dependencies due to a new test module- will investigate soon.)
Nevertheless all tests run fine from Eclipse, so if any changes to the main logic are needed upon review we can just rebase and rerun the tests.

cc/ @rodrigopaulino @brandizzi