### PR TITLE
[TS] LPS-72944 Asset types without search support are shown as available in Search portlet - Configuration 

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
@@ -44,7 +44,7 @@ List<KeyValuePair> availableAssetTypes = new ArrayList<KeyValuePair>();
 for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getAssetRendererFactories(company.getCompanyId())) {
 	String className = assetRendererFactory.getClassName();
 
-	if (!ArrayUtil.contains(assetTypes, className)) {
+	if (assetRendererFactory.isSearchable() && !ArrayUtil.contains(assetTypes, className)) {
 		availableAssetTypes.add(new KeyValuePair(className, ResourceActionsUtil.getModelResource(locale, className)));
 	}
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-72944

Hi Mike,

The same check already exists in https://github.com/lipusz/liferay-portal/blob/master/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/AssetEntriesSearchFacet.java#L167.

/cc @amadeafejes