### PR TITLE
Fast Permission Indexing: Use contributors

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryRelatedEntryBaseModelDocumentContributor.java
+++ b/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryRelatedEntryBaseModelDocumentContributor.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentContributor;
+import com.liferay.portal.kernel.search.DocumentHelper;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.RelatedEntryIndexer;
+import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eric Yan
+ */
+@Component(
+	immediate = true,
+	property = {
+		"base.model.document.contributor=true",
+		"indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry"
+	},
+	service = DocumentContributor.class
+)
+public class DLFileEntryRelatedEntryBaseModelDocumentContributor
+	implements DocumentContributor {
+
+	@Override
+	public void contribute(Document document, BaseModel baseModel) {
+		if (!(baseModel instanceof DLFileEntry)) {
+			return;
+		}
+
+		DLFileEntry dlFileEntry = (DLFileEntry)baseModel;
+
+		if (!dlFileEntry.isInHiddenFolder()) {
+			return;
+		}
+
+		List<RelatedEntryIndexer> relatedEntryIndexers =
+			_relatedEntryIndexerRegistry.getRelatedEntryIndexers(
+				dlFileEntry.getClassName());
+
+		if (relatedEntryIndexers != null) {
+			DocumentHelper documentHelper = new DocumentHelper(document);
+
+			documentHelper.setAttachmentOwnerKey(
+				_portal.getClassNameId(dlFileEntry.getClassName()),
+				dlFileEntry.getClassPK());
+
+			document.addKeyword(Field.RELATED_ENTRY, true);
+		}
+	}
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private RelatedEntryIndexerRegistry _relatedEntryIndexerRegistry;
+
+}

--- a/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/MBMessageIndexer.java
+++ b/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/MBMessageIndexer.java
@@ -300,8 +300,6 @@ public class MBMessageIndexer
 					if (comment != null) {
 						relatedEntryIndexer.addRelatedEntryFields(
 							document, comment);
-
-						document.addKeyword(Field.RELATED_ENTRY, true);
 					}
 				}
 			}

--- a/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/MBMessageRelatedEntryBaseModelDocumentContributor.java
+++ b/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/MBMessageRelatedEntryBaseModelDocumentContributor.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.internal.search;
+
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.portal.kernel.comment.Comment;
+import com.liferay.portal.kernel.comment.CommentManager;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentContributor;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.RelatedEntryIndexer;
+import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eric Yan
+ */
+@Component(
+	immediate = true,
+	property = {
+		"base.model.document.contributor=true",
+		"indexer.class.name=com.liferay.message.boards.model.MBMessage"
+	},
+	service = DocumentContributor.class
+)
+public class MBMessageRelatedEntryBaseModelDocumentContributor
+	implements DocumentContributor {
+
+	@Override
+	public void contribute(Document document, BaseModel baseModel) {
+		if (!(baseModel instanceof MBMessage)) {
+			return;
+		}
+
+		MBMessage mbMessage = (MBMessage)baseModel;
+
+		if (mbMessage.isDiscussion()) {
+			List<RelatedEntryIndexer> relatedEntryIndexers =
+				_relatedEntryIndexerRegistry.getRelatedEntryIndexers(
+					mbMessage.getClassName());
+
+			if ((relatedEntryIndexers != null) &&
+				!relatedEntryIndexers.isEmpty()) {
+
+				Comment comment = commentManager.fetchComment(
+					mbMessage.getMessageId());
+
+				if (comment != null) {
+					document.addKeyword(Field.RELATED_ENTRY, true);
+				}
+			}
+		}
+	}
+
+	@Reference
+	protected CommentManager commentManager;
+
+	@Reference
+	private RelatedEntryIndexerRegistry _relatedEntryIndexerRegistry;
+
+}

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/BaseCalendarIndexerTestCase.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/BaseCalendarIndexerTestCase.java
@@ -21,7 +21,7 @@ import com.liferay.calendar.service.CalendarLocalService;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.IndexerRegistry;
-import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.test.rule.Inject;
 
@@ -46,7 +46,7 @@ public abstract class BaseCalendarIndexerTestCase {
 	}
 
 	protected CalendarFieldsFixture createCalendarFieldsFixture() {
-		return new CalendarFieldsFixture(roleLocalService);
+		return new CalendarFieldsFixture(resourcePermissionLocalService);
 	}
 
 	protected CalendarFixture createCalendarFixture() {
@@ -89,7 +89,7 @@ public abstract class BaseCalendarIndexerTestCase {
 	protected IndexerRegistry indexerRegistry;
 
 	@Inject
-	protected RoleLocalService roleLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
 
 	@DeleteAfterTestRun
 	private final List<CalendarBooking> _calendarBookings = new ArrayList<>(1);

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarIndexerIndexedFieldsTest.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarIndexerIndexedFieldsTest.java
@@ -107,6 +107,8 @@ public class CalendarIndexerIndexedFieldsTest
 		Document document = calendarSearchFixture.searchOnlyOne(
 			keywords, LocaleUtil.HUNGARY);
 
+		calendarFieldsFixture.postProcessDocument(document);
+
 		FieldValuesAssert.assertFieldValues(map, document, keywords);
 	}
 
@@ -136,6 +138,8 @@ public class CalendarIndexerIndexedFieldsTest
 
 		Document document = calendarSearchFixture.searchOnlyOne(
 			keywords, LocaleUtil.BRAZIL);
+
+		calendarFieldsFixture.postProcessDocument(document);
 
 		FieldValuesAssert.assertFieldValues(map, document, keywords);
 	}
@@ -196,8 +200,9 @@ public class CalendarIndexerIndexedFieldsTest
 
 		populateCalendarResource(calendar.getCalendarResource(), calendar, map);
 
-		calendarFieldsFixture.populateGroupRoleId(map);
-		calendarFieldsFixture.populateRoleId("Guest", map);
+		calendarFieldsFixture.populateRoleIdFields(
+			calendar.getCompanyId(), calendar.getModelClassName(),
+			calendar.getCalendarId(), calendar.getGroupId(), null, map);
 		calendarFieldsFixture.populateUID(calendar, map);
 	}
 

--- a/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
@@ -69,10 +69,7 @@ public class FieldValuesAssert {
 					String[] fieldValues = field.getValues();
 
 					if ((fieldValues != null) && (fieldValues.length > 1)) {
-						ArrayList<String> list = new ArrayList<>(
-							Arrays.asList(fieldValues));
-
-						return list.toString();
+						return Arrays.toString(fieldValues);
 					}
 
 					return field.getValue();

--- a/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/FieldValuesAssert.java
@@ -17,6 +17,8 @@ package com.liferay.portal.search.test.util;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -63,6 +65,15 @@ public class FieldValuesAssert {
 				Map.Entry::getKey,
 				entry -> {
 					Field field = entry.getValue();
+
+					String[] fieldValues = field.getValues();
+
+					if ((fieldValues != null) && (fieldValues.length > 1)) {
+						ArrayList<String> list = new ArrayList<>(
+							Arrays.asList(fieldValues));
+
+						return list.toString();
+					}
 
 					return field.getValue();
 				}));

--- a/modules/apps/foundation/portal-search/portal-search-test/build.gradle
+++ b/modules/apps/foundation/portal-search/portal-search-test/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile project(":apps:collaboration:message-boards:message-boards-api")
+	testIntegrationCompile project(":apps:forms-and-workflow:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationCompile project(":apps:forms-and-workflow:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationCompile project(":apps:foundation:portal-search:portal-search-api")
 	testIntegrationCompile project(":apps:static:osgi:osgi-util")

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/AssetPermissionTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/AssetPermissionTest.java
@@ -1,0 +1,399 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.IdempotentRetryAssert;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerTestRule;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Wade Cao
+ * @author Eric Yan
+ */
+@RunWith(Arquillian.class)
+@Sync
+public class AssetPermissionTest extends BaseAssetPermissionTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+
+		setGroup(journalArticleFixture.addGroup());
+		setIndexerClass(JournalArticle.class);
+		setUser(journalArticleFixture.addUser());
+	}
+
+	@Test
+	public void testJournalArticle() throws Exception {
+		String content = RandomTestUtil.randomString();
+		Locale locale = LocaleUtil.BRAZIL;
+		String title = RandomTestUtil.randomString();
+
+		JournalArticle journalArticle = journalArticleFixture.addJournalArticle(
+			title, locale, content, journalArticleFixture.getServiceContext());
+
+		Map<String, String> documentMap = new HashMap<>();
+
+		populateExpectedFieldValues(journalArticle, documentMap);
+
+		assertJournalArticle(title, locale, documentMap);
+	}
+
+	@Test
+	public void testJournalArticlePermissions() throws Exception {
+		String content = RandomTestUtil.randomString();
+		Locale locale = LocaleUtil.BRAZIL;
+		String title = RandomTestUtil.randomString();
+
+		JournalArticle journalArticle = journalArticleFixture.addJournalArticle(
+			title, locale, content, journalArticleFixture.getServiceContext());
+
+		Map<String, String> documentMap = new HashMap<>();
+
+		populateExpectedFieldValues(journalArticle, documentMap);
+
+		assertJournalArticle(title, locale, documentMap);
+
+		RoleTestUtil.removeResourcePermission(
+			RoleConstants.GUEST, journalArticle.getModelClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(journalArticle.getResourcePrimKey()),
+			ActionKeys.VIEW);
+
+		String documentMapRoleId = documentMap.get(Field.ROLE_ID);
+		String expectedRoleId = String.valueOf(
+			journalArticleFieldsFixture.getRoleId(
+				journalArticle.getCompanyId(), RoleConstants.OWNER));
+
+		Assert.assertNotEquals(documentMapRoleId, expectedRoleId);
+		Assert.assertTrue(
+			documentMap.replace(
+				Field.ROLE_ID, documentMapRoleId, expectedRoleId));
+
+		assertJournalArticle(title, locale, documentMap);
+
+		RoleTestUtil.removeResourcePermission(
+			RoleConstants.SITE_MEMBER, journalArticle.getModelClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(journalArticle.getResourcePrimKey()),
+			ActionKeys.VIEW);
+
+		Assert.assertTrue(documentMap.containsKey(Field.GROUP_ROLE_ID));
+
+		documentMap.remove(Field.GROUP_ROLE_ID);
+
+		Assert.assertFalse(documentMap.containsKey(Field.GROUP_ROLE_ID));
+
+		assertJournalArticle(title, locale, documentMap);
+	}
+
+	@Test
+	public void testJournalArticleReindex() throws Exception {
+		String content = RandomTestUtil.randomString();
+		Locale locale = LocaleUtil.BRAZIL;
+		String title = RandomTestUtil.randomString();
+
+		JournalArticle journalArticle = journalArticleFixture.addJournalArticle(
+			title, locale, content, journalArticleFixture.getServiceContext());
+
+		Map<String, String> documentMap = new HashMap<>();
+
+		populateExpectedFieldValues(journalArticle, documentMap);
+
+		assertJournalArticle(title, locale, documentMap);
+
+		journalArticleSearchFixture.reindex(journalArticle);
+
+		Thread.sleep(3000);
+
+		assertJournalArticle(title, locale, documentMap);
+	}
+
+	protected void assertJournalArticle(
+			String keywords, Locale locale, Map<String, String> expectedValues)
+		throws Exception {
+
+		IdempotentRetryAssert.retryAssert(
+			3, TimeUnit.SECONDS,
+			() -> doAssertJournalArticle(keywords, locale, expectedValues));
+	}
+
+	protected Void doAssertJournalArticle(
+		String keywords, Locale locale, Map<String, String> expectedValues) {
+
+		Document document = journalArticleSearchFixture.searchOnlyOne(
+			keywords, locale);
+
+		journalArticleFieldsFixture.postProcessDocument(document);
+
+		FieldValuesAssert.assertFieldValues(expectedValues, document, keywords);
+
+		return null;
+	}
+
+	protected void populateExpectedFieldValues(
+			JournalArticle journalArticle, Map<String, String> map)
+		throws Exception {
+
+		map.put(Field.ARTICLE_ID, journalArticle.getArticleId());
+		map.put(
+			Field.ARTICLE_ID.concat("_String_sortable"),
+			journalArticle.getArticleId());
+		map.put(Field.CLASS_NAME_ID, "0");
+		map.put(Field.CLASS_PK, "0");
+
+		DDMStructure ddmStructure = journalArticle.getDDMStructure();
+
+		map.put(
+			Field.CLASS_TYPE_ID, String.valueOf(ddmStructure.getStructureId()));
+
+		map.put(
+			Field.COMPANY_ID, String.valueOf(journalArticle.getCompanyId()));
+		map.put("ddmStructureKey", journalArticle.getDDMStructureKey());
+		map.put("ddmTemplateKey", journalArticle.getDDMTemplateKey());
+		map.put(Field.ENTRY_CLASS_NAME, journalArticle.getModelClassName());
+		map.put(
+			Field.ENTRY_CLASS_PK,
+			String.valueOf(journalArticle.getResourcePrimKey()));
+		map.put(Field.FOLDER_ID, String.valueOf(journalArticle.getFolderId()));
+		map.put(Field.GROUP_ID, String.valueOf(journalArticle.getGroupId()));
+		map.put("head", "true");
+		map.put("headListable", "true");
+		map.put("latest", "true");
+		map.put(Field.LAYOUT_UUID, journalArticle.getLayoutUuid());
+		map.put(Field.PRIORITY, "0.0");
+
+		if (journalArticleFieldsFixture.isSearchEngineSolr()) {
+			map.put(Field.PRIORITY.concat("_sortable"), "0.0");
+		}
+
+		map.put(
+			Field.ROOT_ENTRY_CLASS_PK,
+			String.valueOf(journalArticle.getResourcePrimKey()));
+		map.put(
+			Field.SCOPE_GROUP_ID, String.valueOf(journalArticle.getGroupId()));
+		map.put(Field.STAGING_GROUP, "false");
+		map.put(Field.STATUS, String.valueOf(journalArticle.getStatus()));
+
+		ArrayList<String> treePathValues = new ArrayList<>(
+			Arrays.asList(
+				StringUtil.split(
+					journalArticle.getTreePath(), CharPool.SLASH)));
+
+		if (treePathValues.size() == 1) {
+			map.put(Field.TREE_PATH, treePathValues.get(0));
+		}
+		else if (treePathValues.size() > 1) {
+			map.put(Field.TREE_PATH, treePathValues.toString());
+		}
+
+		map.put(Field.USER_ID, String.valueOf(journalArticle.getUserId()));
+		map.put(
+			Field.USER_NAME,
+			StringUtil.lowerCase(journalArticle.getUserName()));
+		map.put(Field.VERSION, String.valueOf(journalArticle.getVersion()));
+		map.put("visible", "true");
+
+		populateJournalArticleContent(journalArticle, map);
+		populateJournalArticleDateFields(journalArticle, map);
+		populateJournalArticleLocalizedTitleFields(journalArticle, map);
+		populateJournalArticleTitleFields(journalArticle, map);
+
+		journalArticleFieldsFixture.populateRoleIdFields(
+			journalArticle.getCompanyId(), journalArticle.getModelClassName(),
+			journalArticle.getResourcePrimKey(), journalArticle.getGroupId(),
+			null, map);
+		journalArticleFieldsFixture.populateUID(
+			journalArticle.getId(), journalArticle.getModelClassName(), map);
+	}
+
+	protected void populateJournalArticleContent(
+			JournalArticle journalArticle, Map<String, String> map)
+		throws Exception {
+
+		String content = journalArticle.getContent();
+
+		com.liferay.portal.kernel.xml.Document document = SAXReaderUtil.read(
+			content);
+
+		Element rootElement = document.getRootElement();
+
+		List<String> availableLocales = Arrays.asList(
+			StringUtil.split(rootElement.attributeValue("available-locales")));
+
+		String defaultLanguageId = LanguageUtil.getLanguageId(
+			LocaleUtil.getDefault());
+
+		DDMStructure ddmStructure = journalArticle.getDDMStructure();
+
+		long ddmStructureId = ddmStructure.getStructureId();
+
+		for (String languageId : journalArticle.getAvailableLanguageIds()) {
+			if (availableLocales.contains(languageId)) {
+				String actualContent = journalArticleFixture.getActualContent(
+					journalArticle, languageId);
+				String fieldName = StringBundler.concat(
+					Field.CONTENT, StringPool.UNDERLINE, languageId);
+
+				if (languageId.equals(defaultLanguageId)) {
+					fieldName = Field.CONTENT;
+				}
+
+				map.put(fieldName, actualContent);
+
+				String key = StringBundler.concat(
+					"ddm__text__", String.valueOf(ddmStructureId),
+					StringPool.DOUBLE_UNDERLINE, fieldName);
+
+				map.put(key, actualContent);
+				map.put(
+					key.concat("_String_sortable"),
+					StringUtil.lowerCase(actualContent));
+			}
+		}
+	}
+
+	protected void populateJournalArticleDateFields(
+		JournalArticle journalArticle, Map<String, String> map) {
+
+		Format dateFormat = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			PropsUtil.get(PropsKeys.INDEX_DATE_FORMAT_PATTERN));
+
+		Date expirationDate = new Date(Long.MAX_VALUE);
+
+		if (journalArticleFieldsFixture.isSearchEngineElasticsearch()) {
+			dateFormat = FastDateFormatFactoryUtil.getSimpleDateFormat(
+				"yyyyMMddHHmmss");
+
+			map.put(Field.EXPIRATION_DATE, "99950812133000");
+		}
+		else {
+			map.put(Field.EXPIRATION_DATE, dateFormat.format(expirationDate));
+		}
+
+		map.put(
+			Field.CREATE_DATE,
+			dateFormat.format(journalArticle.getCreateDate()));
+		map.put(
+			Field.CREATE_DATE.concat("_sortable"),
+			String.valueOf(journalArticle.getCreateDate().getTime()));
+		map.put(
+			"displayDate", dateFormat.format(journalArticle.getDisplayDate()));
+		map.put(
+			"displayDate_sortable",
+			String.valueOf(journalArticle.getDisplayDate().getTime()));
+		map.put(
+			Field.EXPIRATION_DATE.concat("_sortable"),
+			String.valueOf(expirationDate.getTime()));
+		map.put(
+			Field.MODIFIED_DATE,
+			dateFormat.format(journalArticle.getModifiedDate()));
+		map.put(
+			Field.MODIFIED_DATE.concat("_sortable"),
+			String.valueOf(journalArticle.getModifiedDate().getTime()));
+
+		Date publishDate = journalArticle.getDisplayDate();
+
+		map.put(Field.PUBLISH_DATE, dateFormat.format(publishDate));
+		map.put(
+			Field.PUBLISH_DATE.concat("_sortable"),
+			String.valueOf(publishDate.getTime()));
+	}
+
+	protected void populateJournalArticleLocalizedTitleFields(
+		JournalArticle journalArticle, Map<String, String> map) {
+
+		for (Locale locale :
+				LanguageUtil.getAvailableLocales(journalArticle.getGroupId())) {
+
+			String title = StringUtil.lowerCase(
+				journalArticle.getTitle(locale));
+
+			map.put("localized_title", title);
+
+			String key = StringBundler.concat(
+				"localized_title_", LanguageUtil.getLanguageId(locale));
+
+			map.put(key, title);
+			map.put(key.concat("_sortable"), title);
+		}
+	}
+
+	protected void populateJournalArticleTitleFields(
+		JournalArticle journalArticle, Map<String, String> map) {
+
+		String[] languageIds = LocalizationUtil.getAvailableLanguageIds(
+			journalArticle.getDocument());
+
+		for (String languageId : languageIds) {
+			map.put(
+				LocalizationUtil.getLocalizedName(Field.TITLE, languageId),
+				journalArticle.getTitle(languageId));
+		}
+	}
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/BaseAssetPermissionTestCase.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/BaseAssetPermissionTestCase.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.test;
+
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.test.rule.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+
+/**
+ * @author Wade Cao
+ * @author Eric Yan
+ */
+public abstract class BaseAssetPermissionTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		journalArticleFixture = createJournalArticleFixture();
+
+		journalArticleFixture.setUp();
+
+		journalArticleFieldsFixture = createJournalArticleFieldsFixture();
+		journalArticleSearchFixture = createJournalArticleSearchFixture();
+	}
+
+	protected JournalArticleFieldsFixture createJournalArticleFieldsFixture() {
+		return new JournalArticleFieldsFixture(
+			_resourcePermissionLocalService, _roleLocalService);
+	}
+
+	protected JournalArticleFixture createJournalArticleFixture() {
+		return new JournalArticleFixture(
+			_journalArticleLocalService, _groups, _users);
+	}
+
+	protected JournalArticleSearchFixture createJournalArticleSearchFixture() {
+		return new JournalArticleSearchFixture(_indexerRegistry);
+	}
+
+	protected void setGroup(Group group) {
+		journalArticleFixture.setGroup(group);
+		journalArticleSearchFixture.setGroup(group);
+	}
+
+	protected void setIndexerClass(Class<?> clazz) {
+		journalArticleSearchFixture.setIndexerClass(clazz);
+	}
+
+	protected void setUser(User user) {
+		journalArticleFixture.setUser(user);
+		journalArticleSearchFixture.setUser(user);
+	}
+
+	protected JournalArticleFieldsFixture journalArticleFieldsFixture;
+	protected JournalArticleFixture journalArticleFixture;
+	protected JournalArticleSearchFixture journalArticleSearchFixture;
+
+	@DeleteAfterTestRun
+	private final List<Group> _groups = new ArrayList<>(1);
+
+	@Inject
+	private IndexerRegistry _indexerRegistry;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>(1);
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/JournalArticleFieldsFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/JournalArticleFieldsFixture.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.test;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchEngine;
+import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Wade Cao
+ * @author Eric Yan
+ */
+public class JournalArticleFieldsFixture {
+
+	public JournalArticleFieldsFixture(
+		ResourcePermissionLocalService resourcePermissionLocalService,
+		RoleLocalService roleLocalService) {
+
+		_resourcePermissionLocalService = resourcePermissionLocalService;
+		_roleLocalService = roleLocalService;
+	}
+
+	public long getRoleId(long companyId, String name) throws PortalException {
+		Role role = _roleLocalService.getRole(companyId, name);
+
+		return role.getRoleId();
+	}
+
+	public boolean isSearchEngineElasticsearch() {
+		SearchEngine searchEngine = SearchEngineHelperUtil.getSearchEngine(
+			SearchEngineHelperUtil.getDefaultSearchEngineId());
+
+		String vendor = searchEngine.getVendor();
+
+		return vendor.equals("Elasticsearch");
+	}
+
+	public boolean isSearchEngineSolr() {
+		SearchEngine searchEngine = SearchEngineHelperUtil.getSearchEngine(
+			SearchEngineHelperUtil.getDefaultSearchEngineId());
+
+		String vendor = searchEngine.getVendor();
+
+		return vendor.equals("Solr");
+	}
+
+	public void populateRoleIdFields(
+			long companyId, String className, long classPK, long groupId,
+			String viewActionId, Map<String, String> fieldValues)
+		throws PortalException {
+
+		if (Validator.isNull(viewActionId)) {
+			viewActionId = ActionKeys.VIEW;
+		}
+
+		List<Role> roles = _resourcePermissionLocalService.getRoles(
+			companyId, className, ResourceConstants.SCOPE_INDIVIDUAL,
+			Long.toString(classPK), viewActionId);
+
+		List<String> groupRoleIds = new ArrayList<>();
+		List<Long> roleIds = new ArrayList<>();
+
+		for (Role role : roles) {
+			if ((role.getType() == RoleConstants.TYPE_ORGANIZATION) ||
+				(role.getType() == RoleConstants.TYPE_SITE)) {
+
+				groupRoleIds.add(groupId + StringPool.DASH + role.getRoleId());
+			}
+			else {
+				roleIds.add(role.getRoleId());
+			}
+		}
+
+		if (groupRoleIds.size() == 1) {
+			fieldValues.put(Field.GROUP_ROLE_ID, groupRoleIds.get(0));
+		}
+		else if (groupRoleIds.size() > 1) {
+			fieldValues.put(Field.GROUP_ROLE_ID, groupRoleIds.toString());
+		}
+
+		if (roleIds.size() == 1) {
+			fieldValues.put(Field.ROLE_ID, String.valueOf(roleIds.get(0)));
+		}
+		else if (roleIds.size() > 1) {
+			fieldValues.put(Field.ROLE_ID, roleIds.toString());
+		}
+	}
+
+	public void populateUID(
+		long id, String modelClassName, Map<String, String> fieldValues) {
+
+		String uid = modelClassName + "_PORTLET_" + id;
+
+		fieldValues.put(Field.UID, uid);
+	}
+
+	public void postProcessDocument(Document document) {
+		if (isSearchEngineSolr()) {
+			document.remove("score");
+		}
+	}
+
+	private final ResourcePermissionLocalService
+		_resourcePermissionLocalService;
+	private final RoleLocalService _roleLocalService;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/JournalArticleFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/JournalArticleFixture.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.test;
+
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.model.JournalArticleDisplay;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.journal.util.JournalArticleContent;
+import com.liferay.portal.service.test.ServiceTestUtil;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Wade Cao
+ * @author Eric Yan
+ */
+public class JournalArticleFixture {
+
+	public JournalArticleFixture(
+		JournalArticleLocalService journalArticleLocalService,
+		List<Group> groups, List<User> users) {
+
+		_journalArticleLocalService = journalArticleLocalService;
+
+		_groups = groups;
+		_users = users;
+	}
+
+	public Group addGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		_groups.add(group);
+
+		return group;
+	}
+
+	public JournalArticle addJournalArticle(
+			String title, Locale locale, String content,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		Map<Locale, String> titleMap = new HashMap<>();
+
+		titleMap.put(locale, title);
+
+		Locale defaultLocale = LocaleUtil.getSiteDefault();
+
+		if (!locale.equals(defaultLocale)) {
+			titleMap.put(defaultLocale, title);
+		}
+
+		JournalArticleContent journalArticleContent =
+			new JournalArticleContent() {
+				{
+					name = "content";
+					defaultLocale = LocaleUtil.US;
+
+					put(locale, content);
+				}
+			};
+
+		String ddmStructureKey = "BASIC-WEB-CONTENT";
+		String ddmTemplateKey = "BASIC-WEB-CONTENT";
+
+		return _journalArticleLocalService.addArticle(
+			serviceContext.getUserId(), serviceContext.getScopeGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, titleMap, null,
+			journalArticleContent.getContentString(), ddmStructureKey,
+			ddmTemplateKey, serviceContext);
+	}
+
+	public User addUser() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		_users.add(user);
+
+		return user;
+	}
+
+	public String getActualContent(
+			JournalArticle journalArticle, String languageId)
+		throws Exception {
+
+		JournalArticleDisplay journalArticleDisplay =
+			_journalArticleLocalService.getArticleDisplay(
+				journalArticle.getGroupId(), journalArticle.getArticleId(),
+				Constants.VIEW, languageId,
+				getServiceContext().getThemeDisplay());
+
+		return journalArticleDisplay.getContent();
+	}
+
+	public ServiceContext getServiceContext() throws PortalException {
+		return ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), getUserId());
+	}
+
+	public void setGroup(Group group) {
+		_group = group;
+	}
+
+	public void setUp() throws Exception {
+		ServiceTestUtil.setUser(TestPropsValues.getUser());
+
+		CompanyThreadLocal.setCompanyId(TestPropsValues.getCompanyId());
+	}
+
+	public void setUser(User user) {
+		_user = user;
+	}
+
+	protected long getUserId() throws PortalException {
+		if (_user != null) {
+			return _user.getUserId();
+		}
+
+		return TestPropsValues.getUserId();
+	}
+
+	private Group _group;
+	private final List<Group> _groups;
+	private final JournalArticleLocalService _journalArticleLocalService;
+	private User _user;
+	private final List<User> _users;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/JournalArticleSearchFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/internal/test/JournalArticleSearchFixture.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.test;
+
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.QueryConfig;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.search.test.util.HitsAssert;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * @author Wade Cao
+ * @author Eric Yan
+ */
+public class JournalArticleSearchFixture {
+
+	public JournalArticleSearchFixture(IndexerRegistry indexerRegistry) {
+		_indexerRegistry = indexerRegistry;
+	}
+
+	public SearchContext getSearchContext(String keywords, Locale locale) {
+		SearchContext searchContext = new SearchContext();
+
+		try {
+			searchContext.setCompanyId(TestPropsValues.getCompanyId());
+			searchContext.setUserId(getUserId());
+		}
+		catch (PortalException pe) {
+			throw new RuntimeException(pe);
+		}
+
+		searchContext.setGroupIds(new long[] {_group.getGroupId()});
+		searchContext.setKeywords(keywords);
+		searchContext.setLocale(Objects.requireNonNull(locale));
+
+		QueryConfig queryConfig = searchContext.getQueryConfig();
+
+		queryConfig.setSelectedFieldNames(StringPool.STAR);
+
+		return searchContext;
+	}
+
+	public void reindex(JournalArticle journalArticle) throws SearchException {
+		((Indexer<JournalArticle>)_indexer).reindex(journalArticle);
+	}
+
+	public Document searchOnlyOne(String keywords, Locale locale) {
+		return HitsAssert.assertOnlyOne(
+			search(getSearchContext(keywords, locale)));
+	}
+
+	public void setGroup(Group group) {
+		_group = group;
+	}
+
+	public void setIndexerClass(Class<?> clazz) {
+		_indexer = _indexerRegistry.getIndexer(clazz);
+	}
+
+	public void setUser(User user) {
+		_user = user;
+	}
+
+	protected long getUserId() throws PortalException {
+		if (_user != null) {
+			return _user.getUserId();
+		}
+
+		return TestPropsValues.getUserId();
+	}
+
+	protected Hits search(SearchContext searchContext) {
+		try {
+			return _indexer.search(searchContext);
+		}
+		catch (SearchException se) {
+			throw new RuntimeException(se);
+		}
+	}
+
+	private Group _group;
+	private Indexer<?> _indexer;
+	private final IndexerRegistry _indexerRegistry;
+	private User _user;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/bnd.bnd
+++ b/modules/apps/foundation/portal-search/portal-search/bnd.bnd
@@ -1,6 +1,7 @@
 Bundle-Name: Liferay Portal Search
 Bundle-SymbolicName: com.liferay.portal.search
 Bundle-Version: 5.0.0
+DynamicImport-Package: *
 Import-Package:\
 	com.liferay.portal.kernel.search;version="[7.1.0,8)",\
 	\

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
@@ -45,7 +45,7 @@ public class BaseModelRetrieverImpl implements BaseModelRetriever {
 		String className, long classPK) {
 
 		Optional<BaseModel<?>> baseModel = null;
-		
+
 		try {
 			Class clazz = Class.forName(className);
 

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
@@ -47,18 +47,17 @@ public class BaseModelRetrieverImpl implements BaseModelRetriever {
 		Optional<BaseModel<?>> baseModel = null;
 
 		try {
-			Class clazz = Class.forName(className);
+			Class<?> clazz = Class.forName(className);
 
 			if (ResourcedModel.class.isAssignableFrom(clazz)) {
-				baseModel = _getAssetBaseModel(
-					className, classPK);
+				baseModel = _getAssetBaseModel(className, classPK);
 			}
 			else if (BaseModel.class.isAssignableFrom(clazz)) {
 				baseModel = _getPersistedModel(className, classPK);
 			}
 		}
-		catch (ClassNotFoundException e) {
-			throw new SystemException(e);
+		catch (ClassNotFoundException cnfe) {
+			throw new SystemException(cnfe);
 		}
 
 		return baseModel;

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchConfiguratorImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchConfiguratorImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.internal.indexer;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
 import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
@@ -68,7 +69,10 @@ public class ModelSearchConfiguratorImpl<T extends BaseModel<?>>
 
 		_modelDocumentContributors = ServiceTrackerListFactory.open(
 			bundleContext, ModelDocumentContributor.class,
-			"(indexer.class.name=" + modelSearchSettings.getClassName() + ")");
+			StringBundler.concat(
+				"(&(!(base.model.document.contributor=true))",
+				"(indexer.class.name=", modelSearchSettings.getClassName(),
+				"))"));
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchConfiguratorServiceTrackerCustomizer.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/ModelSearchConfiguratorServiceTrackerCustomizer.java
@@ -168,7 +168,9 @@ public class ModelSearchConfiguratorServiceTrackerCustomizer
 
 		_documentContributors = ServiceTrackerListFactory.open(
 			_bundleContext, DocumentContributor.class,
-			"(!(indexer.class.name=*))");
+			StringBundler.concat(
+				"(&(!(base.model.document.contributor=true))",
+				"(!(indexer.class.name=*)))"));
 
 		_keywordQueryContributors = ServiceTrackerListFactory.open(
 			_bundleContext, KeywordQueryContributor.class,

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionDocumentContributorImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionDocumentContributorImpl.java
@@ -126,11 +126,22 @@ public class SearchPermissionDocumentContributorImpl
 				}
 			}
 
-			doc.addKeyword(
-				Field.ROLE_ID, roleIds.toArray(new Long[roleIds.size()]));
-			doc.addKeyword(
-				Field.GROUP_ROLE_ID,
-				groupRoleIds.toArray(new String[groupRoleIds.size()]));
+			if (roleIds.isEmpty()) {
+				doc.addKeyword(Field.ROLE_ID, (Long)null);
+			}
+			else {
+				doc.addKeyword(
+					Field.ROLE_ID, roleIds.toArray(new Long[roleIds.size()]));
+			}
+
+			if (groupRoleIds.isEmpty()) {
+				doc.addKeyword(Field.GROUP_ROLE_ID, (String)null);
+			}
+			else {
+				doc.addKeyword(
+					Field.GROUP_ROLE_ID,
+					groupRoleIds.toArray(new String[groupRoleIds.size()]));
+			}
 		}
 		catch (NoSuchResourceException nsre) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
@@ -91,7 +91,7 @@ public class SearchPermissionIndexWriterImpl
 				for (String relatedPermissionFieldName :
 						relatedPermissionFieldNames) {
 
-					if (document.hasField(relatedPermissionFieldName)) {
+					if (indexerDocument.hasField(relatedPermissionFieldName)) {
 						document.addKeyword(
 							relatedPermissionFieldName,
 							indexerDocument.get(relatedPermissionFieldName));

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
@@ -14,12 +14,23 @@
 
 package com.liferay.portal.search.internal.permission;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.search.index.UpdateDocumentIndexWriter;
 import com.liferay.portal.search.indexer.BaseModelDocumentFactory;
 import com.liferay.portal.search.permission.SearchPermissionDocumentContributor;
 import com.liferay.portal.search.permission.SearchPermissionIndexWriter;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -36,17 +47,78 @@ public class SearchPermissionIndexWriterImpl
 		BaseModel<?> baseModel, long companyId, String searchEngineId,
 		boolean commitImmediately) {
 
-		Document document = baseModelDocumentFactory.createDocument(baseModel);
+		Document document = createBasePermissionDocument(baseModel);
 
-		searchPermissionDocumentContributor.addPermissionFields(
-			companyId, document);
+		if (document != null) {
+			searchPermissionDocumentContributor.addPermissionFields(
+				companyId, document);
 
-		updateDocumentIndexWriter.updateDocumentPartially(
-			searchEngineId, companyId, document, commitImmediately);
+			updateDocumentIndexWriter.updateDocumentPartially(
+				searchEngineId, companyId, document, commitImmediately);
+		}
+		else {
+			_log.error(
+				StringBundler.concat(
+					"Unable to update permissions for ",
+					baseModel.getModelClassName(), " with primaryKey ",
+					String.valueOf(baseModel.getPrimaryKeyObj())),
+				new Exception());
+		}
+	}
+
+	protected Document createBasePermissionDocument(BaseModel<?> baseModel) {
+		Indexer<BaseModel<?>> indexer = indexerRegistry.getIndexer(
+			baseModel.getModelClassName());
+
+		if (indexer != null) {
+			try {
+				Document indexerDocument = indexer.getDocument(baseModel);
+				Document document = new DocumentImpl();
+
+				document.addKeyword(
+					Field.ENTRY_CLASS_NAME,
+					indexerDocument.get(Field.ENTRY_CLASS_NAME));
+				document.addKeyword(
+					Field.ENTRY_CLASS_PK,
+					indexerDocument.get(Field.ENTRY_CLASS_PK));
+				document.addKeyword(
+					Field.GROUP_ID, indexerDocument.get(Field.GROUP_ID));
+				document.addKeyword(Field.UID, indexerDocument.get(Field.UID));
+
+				List<String> relatedPermissionFieldNames = Arrays.asList(
+					Field.RELATED_ENTRY, Field.CLASS_NAME_ID, Field.CLASS_PK);
+
+				for (String relatedPermissionFieldName :
+						relatedPermissionFieldNames) {
+
+					if (document.hasField(relatedPermissionFieldName)) {
+						document.addKeyword(
+							relatedPermissionFieldName,
+							indexerDocument.get(relatedPermissionFieldName));
+					}
+				}
+
+				return document;
+			}
+			catch (SearchException se) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Unable to create document with indexer for ",
+							baseModel.getModelClassName()),
+						se);
+				}
+			}
+		}
+
+		return null;
 	}
 
 	@Reference
 	protected BaseModelDocumentFactory baseModelDocumentFactory;
+
+	@Reference
+	protected IndexerRegistry indexerRegistry;
 
 	@Reference
 	protected SearchPermissionDocumentContributor
@@ -54,5 +126,8 @@ public class SearchPermissionIndexWriterImpl
 
 	@Reference
 	protected UpdateDocumentIndexWriter updateDocumentIndexWriter;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SearchPermissionIndexWriterImpl.class);
 
 }

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
@@ -15,7 +15,9 @@
 package com.liferay.portal.search.internal.permission;
 
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.search.index.UpdateDocumentIndexWriter;
 import com.liferay.portal.search.indexer.BaseModelDocumentFactory;
 import com.liferay.portal.search.permission.SearchPermissionDocumentContributor;
@@ -37,6 +39,11 @@ public class SearchPermissionIndexWriterImpl
 		boolean commitImmediately) {
 
 		Document document = baseModelDocumentFactory.createDocument(baseModel);
+
+		if (baseModel instanceof GroupedModel) {
+			document.addKeyword(
+				Field.GROUP_ID, ((GroupedModel)baseModel).getGroupId());
+		}
 
 		searchPermissionDocumentContributor.addPermissionFields(
 			companyId, document);

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
@@ -14,23 +14,12 @@
 
 package com.liferay.portal.search.internal.permission;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Document;
-import com.liferay.portal.kernel.search.DocumentImpl;
-import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.IndexerRegistry;
-import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.search.index.UpdateDocumentIndexWriter;
 import com.liferay.portal.search.indexer.BaseModelDocumentFactory;
 import com.liferay.portal.search.permission.SearchPermissionDocumentContributor;
 import com.liferay.portal.search.permission.SearchPermissionIndexWriter;
-
-import java.util.Arrays;
-import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -47,79 +36,17 @@ public class SearchPermissionIndexWriterImpl
 		BaseModel<?> baseModel, long companyId, String searchEngineId,
 		boolean commitImmediately) {
 
-		Document document = createBasePermissionDocument(baseModel);
+		Document document = baseModelDocumentFactory.createDocument(baseModel);
 
-		if (document != null) {
-			searchPermissionDocumentContributor.addPermissionFields(
-				companyId, document);
+		searchPermissionDocumentContributor.addPermissionFields(
+			companyId, document);
 
-			updateDocumentIndexWriter.updateDocumentPartially(
-				searchEngineId, companyId, document, commitImmediately);
-		}
-		else {
-			_log.error(
-				StringBundler.concat(
-					"Unable to update permissions for ",
-					baseModel.getModelClassName(), " with primaryKey ",
-					String.valueOf(baseModel.getPrimaryKeyObj())),
-				new Exception());
-		}
-	}
-
-	protected Document createBasePermissionDocument(BaseModel<?> baseModel) {
-		//todo this is super expensive.
-		Indexer<BaseModel<?>> indexer = indexerRegistry.getIndexer(
-			baseModel.getModelClassName());
-
-		if (indexer != null) {
-			try {
-				Document indexerDocument = indexer.getDocument(baseModel);
-				Document document = new DocumentImpl();
-
-				document.addKeyword(
-					Field.ENTRY_CLASS_NAME,
-					indexerDocument.get(Field.ENTRY_CLASS_NAME));
-				document.addKeyword(
-					Field.ENTRY_CLASS_PK,
-					indexerDocument.get(Field.ENTRY_CLASS_PK));
-				document.addKeyword(
-					Field.GROUP_ID, indexerDocument.get(Field.GROUP_ID));
-				document.addKeyword(Field.UID, indexerDocument.get(Field.UID));
-
-				List<String> relatedPermissionFieldNames = Arrays.asList(
-					Field.RELATED_ENTRY, Field.CLASS_NAME_ID, Field.CLASS_PK);
-
-				for (String relatedPermissionFieldName :
-						relatedPermissionFieldNames) {
-
-					if (document.hasField(relatedPermissionFieldName)) {
-						document.addKeyword(
-							relatedPermissionFieldName,
-							indexerDocument.get(relatedPermissionFieldName));
-					}
-				}
-
-				return document;
-			}
-			catch (SearchException se) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(
-						StringBundler.concat(
-							"Unable to create document with indexer for ",
-							baseModel.getModelClassName()),
-						se);
-				}
-			}
-		}
-
-		return null;
+		updateDocumentIndexWriter.updateDocumentPartially(
+			searchEngineId, companyId, document, commitImmediately);
 	}
 
 	@Reference
 	protected BaseModelDocumentFactory baseModelDocumentFactory;
-
-	@Reference
-	protected IndexerRegistry indexerRegistry;
 
 	@Reference
 	protected SearchPermissionDocumentContributor
@@ -127,8 +54,5 @@ public class SearchPermissionIndexWriterImpl
 
 	@Reference
 	protected UpdateDocumentIndexWriter updateDocumentIndexWriter;
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		SearchPermissionIndexWriterImpl.class);
 
 }

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
@@ -67,6 +67,7 @@ public class SearchPermissionIndexWriterImpl
 	}
 
 	protected Document createBasePermissionDocument(BaseModel<?> baseModel) {
+		//todo this is super expensive.
 		Indexer<BaseModel<?>> indexer = indexerRegistry.getIndexer(
 			baseModel.getModelClassName());
 

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchPermissionIndexWriterImpl.java
@@ -92,7 +92,7 @@ public class SearchPermissionIndexWriterImpl
 				for (String relatedPermissionFieldName :
 						relatedPermissionFieldNames) {
 
-					if (indexerDocument.hasField(relatedPermissionFieldName)) {
+					if (document.hasField(relatedPermissionFieldName)) {
 						document.addKeyword(
 							relatedPermissionFieldName,
 							indexerDocument.get(relatedPermissionFieldName));

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/document/DefaultElasticsearchDocumentFactory.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/document/DefaultElasticsearchDocumentFactory.java
@@ -102,10 +102,11 @@ public class DefaultElasticsearchDocumentFactory
 
 			for (String value : values) {
 				if (value == null) {
-					continue;
+					valuesList.add(null);
 				}
-
-				valuesList.add(value.trim());
+				else {
+					valuesList.add(value.trim());
+				}
 			}
 
 			if (valuesList.isEmpty()) {

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/document/DefaultElasticsearchDocumentFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/document/DefaultElasticsearchDocumentFactoryTest.java
@@ -41,7 +41,7 @@ public class DefaultElasticsearchDocumentFactoryTest {
 
 	@Test
 	public void testNull() throws Exception {
-		assertElasticsearchDocument(null, "{}");
+		assertElasticsearchDocument(null, "{\"field\":null}");
 	}
 
 	@Test

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleBaseModelDocumentContributor.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleBaseModelDocumentContributor.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.search;
+
+import com.liferay.journal.configuration.JournalServiceConfiguration;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentContributor;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eric Yan
+ */
+@Component(
+	immediate = true,
+	property = {
+		"base.model.document.contributor=true",
+		"indexer.class.name=com.liferay.journal.model.JournalArticle"
+	},
+	service = DocumentContributor.class
+)
+public class JournalArticleBaseModelDocumentContributor
+	implements DocumentContributor {
+
+	@Override
+	public void contribute(Document document, BaseModel baseModel) {
+		if (!(baseModel instanceof JournalArticle)) {
+			return;
+		}
+
+		JournalArticle journalArticle = (JournalArticle)baseModel;
+
+		long classPK = journalArticle.getId();
+
+		if (!isIndexAllArticleVersions()) {
+			classPK = journalArticle.getResourcePrimKey();
+		}
+
+		document.addUID(JournalArticle.class.getName(), classPK);
+	}
+
+	protected boolean isIndexAllArticleVersions() {
+		try {
+			JournalServiceConfiguration journalServiceConfiguration =
+				_configurationProvider.getCompanyConfiguration(
+					JournalServiceConfiguration.class,
+					CompanyThreadLocal.getCompanyId());
+
+			return journalServiceConfiguration.indexAllArticleVersionsEnabled();
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalArticleBaseModelDocumentContributor.class);
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+}

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -494,14 +494,6 @@ public class JournalArticleIndexer
 
 		Document document = getBaseModelDocument(CLASS_NAME, journalArticle);
 
-		long classPK = journalArticle.getId();
-
-		if (!isIndexAllArticleVersions()) {
-			classPK = journalArticle.getResourcePrimKey();
-		}
-
-		document.addUID(CLASS_NAME, classPK);
-
 		String articleDefaultLanguageId = LocalizationUtil.getDefaultLanguageId(
 			journalArticle.getDocument());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -414,7 +414,11 @@ public class DLFileEntryIndexer
 		try {
 			dlFileVersion = dlFileEntry.getFileVersion();
 		}
-		catch (NoSuchFileVersionException nsfve) {}
+		catch (NoSuchFileVersionException nsfve) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(nsfve, nsfve);
+			}
+		}
 
 		try {
 			Document document = null;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -51,7 +51,6 @@ import com.liferay.portal.kernel.search.BaseRelatedEntryIndexer;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
-import com.liferay.portal.kernel.search.DocumentHelper;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
 import com.liferay.portal.kernel.search.Indexer;
@@ -522,16 +521,6 @@ public class DLFileEntryIndexer
 
 						relatedEntryIndexer.addRelatedEntryFields(
 							document, new LiferayFileEntry(dlFileEntry));
-
-						DocumentHelper documentHelper = new DocumentHelper(
-							document);
-
-						documentHelper.setAttachmentOwnerKey(
-							PortalUtil.getClassNameId(
-								dlFileEntry.getClassName()),
-							dlFileEntry.getClassPK());
-
-						document.addKeyword(Field.RELATED_ENTRY, true);
 					}
 				}
 			}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -409,11 +409,24 @@ public class DLFileEntryIndexer
 			}
 		}
 
-		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+		DLFileVersion dlFileVersion = null;
 
 		try {
-			Document document = getBaseModelDocument(
-				CLASS_NAME, dlFileEntry, dlFileVersion);
+			dlFileVersion = dlFileEntry.getFileVersion();
+		}
+		catch (NoSuchFileVersionException nsfve) {}
+
+		try {
+			Document document = null;
+
+			if (dlFileVersion != null) {
+				document = getBaseModelDocument(
+					CLASS_NAME, dlFileEntry, dlFileVersion);
+			}
+			else {
+				document = getBaseModelDocument(
+					CLASS_NAME, dlFileEntry, dlFileEntry);
+			}
 
 			if (indexContent) {
 				if (is != null) {
@@ -463,9 +476,14 @@ public class DLFileEntryIndexer
 
 			document.addKeyword(
 				"dataRepositoryId", dlFileEntry.getDataRepositoryId());
-			document.addText(
-				"ddmContent",
-				extractDDMContent(dlFileVersion, LocaleUtil.getSiteDefault()));
+
+			if (dlFileVersion != null) {
+				document.addText(
+					"ddmContent",
+					extractDDMContent(
+						dlFileVersion, LocaleUtil.getSiteDefault()));
+			}
+
 			document.addKeyword("extension", dlFileEntry.getExtension());
 			document.addKeyword(
 				"fileEntryTypeId", dlFileEntry.getFileEntryTypeId());
@@ -478,14 +496,16 @@ public class DLFileEntryIndexer
 			document.addKeyword("readCount", dlFileEntry.getReadCount());
 			document.addKeyword("size", dlFileEntry.getSize());
 
-			ExpandoBridge expandoBridge =
-				ExpandoBridgeFactoryUtil.getExpandoBridge(
-					dlFileEntry.getCompanyId(), DLFileEntry.class.getName(),
-					dlFileVersion.getFileVersionId());
+			if (dlFileVersion != null) {
+				ExpandoBridge expandoBridge =
+					ExpandoBridgeFactoryUtil.getExpandoBridge(
+						dlFileEntry.getCompanyId(), DLFileEntry.class.getName(),
+						dlFileVersion.getFileVersionId());
 
-			ExpandoBridgeIndexerUtil.addAttributes(document, expandoBridge);
+				ExpandoBridgeIndexerUtil.addAttributes(document, expandoBridge);
 
-			addFileEntryTypeAttributes(document, dlFileVersion);
+				addFileEntryTypeAttributes(document, dlFileVersion);
+			}
 
 			if (dlFileEntry.isInHiddenFolder()) {
 				List<RelatedEntryIndexer> relatedEntryIndexers =


### PR DESCRIPTION
Hi @mhan810,

Here is the latest development for Fast Permission Indexing.
Can you help take a look and see what you think of the new approach?

**CI Test Results:** https://github.com/ericyanLr/liferay-portal/pull/65

## Latest Update
As discussed, we will not use indexers to **re-create** the entire document.
Instead, we will generate a document with only the bare minimum fields needed for the partial update.

As a refresher, our previous approach re-created the entire document as an attempt to handle:

- Indexers that modified relevant fields **AFTER** the base model document was created
- Indexers that added relevant fields needed for permissioning, but are normally not included in the **base model document**

Our new approach uses **contributors** to provide the necessary fields for creating our partial update document.

Below will be additional sections with details regarding our new approach.

Please let me know if you have any questions.
Thanks!

---

## New Approach
We will be utilizing **DocumentContributors/ModelDocumentContributors** to provide the **relevant fields** needed for **Fast Permission Indexing**.

The plan is to include these **relevant fields** when creating the **base model document**.

- Implement DocumentContributors : https://github.com/mhan810/liferay-portal/pull/1402/commits/ecdfdd3be7d334698e14fbfb6716c94e1ab85850
- Implement ModelDocumentContributors: https://github.com/mhan810/liferay-portal/pull/1402/commits/402bb0f4e56a47b5f68b7e25c818dae0aafba5a5

### Why both DocumentContributor and ModelDocumentContributor
The main reason is to make this work for both Old Indexers and New Indexers.

If possible, we would only use **ModelDocumentContributor**, but a few indexers still reside in **portal-impl** and this interface is not available in **portal-kernel**.

## Progress
I created a few **contributors** to demonstrate how we could **extract** specific portions of **code from the indexer** and incorporate the logic into the **base model document** instead.

This would ensure that our **base model document** would include the relevant fields needed for fast permission indexing.

Also, since we are using **DocumentContributors**, this should not break the old indexers or the new indexers.

## Next Steps
If this approach works out, we would **continue extracting** out specific portions of **code from indexers** into **contributors**.

## Possible Concern
A possible concern would be customers that have their own custom indexers.

If their custom indexer contains logic that modify relevant fields, they would also need to extract that logic into contributors, or else **Fast Permission Indexing** would not work for their **custom indexer**.

Also, if we ourselves need to **create a new indexer** in the future, we would also need to  **determine which fields** need to be included in the **base model document** and to **create a contributor** specifically for that logic.