### PR TITLE
[TS] LPS-83420 JMX beans not created for liferay/search_*/ MessageBus Destinations

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/AbstractSearchEngineConfigurator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/AbstractSearchEngineConfigurator.java
@@ -330,11 +330,15 @@ public abstract class AbstractSearchEngineConfigurator
 		searchEngineRegistration.setSearchReaderDestinationName(
 			searchReaderDestination.getName());
 
+		registerSearchEngineDestination(searchReaderDestination);
+
 		Destination searchWriterDestination = getSearchWriterDestination(
 			_messageBus, searchEngineId);
 
 		searchEngineRegistration.setSearchWriterDestinationName(
 			searchWriterDestination.getName());
+
+		registerSearchEngineDestination(searchWriterDestination);
 
 		SearchEngineHelper searchEngineHelper = getSearchEngineHelper();
 
@@ -364,23 +368,6 @@ public abstract class AbstractSearchEngineConfigurator
 				_messageBus, searchEngineId);
 		}
 
-		Registry registry = RegistryUtil.getRegistry();
-
-		_destinationServiceRegistrar = registry.getServiceRegistrar(
-			Destination.class);
-
-		Map<String, Object> properties = new HashMap<>();
-
-		properties.put("destination.name", searchReaderDestination.getName());
-
-		_destinationServiceRegistrar.registerService(
-			Destination.class, searchReaderDestination, properties);
-
-		properties.put("destination.name", searchWriterDestination.getName());
-
-		_destinationServiceRegistrar.registerService(
-			Destination.class, searchWriterDestination, properties);
-
 		createSearchEngineListeners(
 			searchEngineId, searchEngine, searchReaderDestination,
 			searchWriterDestination);
@@ -403,6 +390,22 @@ public abstract class AbstractSearchEngineConfigurator
 				invokerMessageListener.getMessageListener(),
 				invokerMessageListener.getClassLoader());
 		}
+	}
+
+	protected void registerSearchEngineDestination(Destination destination) {
+		if (_destinationServiceRegistrar == null) {
+			Registry registry = RegistryUtil.getRegistry();
+
+			_destinationServiceRegistrar = registry.getServiceRegistrar(
+				Destination.class);
+		}
+
+		Map<String, Object> properties = new HashMap<>();
+
+		properties.put("destination.name", destination.getName());
+
+		_destinationServiceRegistrar.registerService(
+			Destination.class, destination, properties);
 	}
 
 	protected void registerSearchEngineMessageListener(
@@ -469,13 +472,13 @@ public abstract class AbstractSearchEngineConfigurator
 	private static final Log _log = LogFactoryUtil.getLog(
 		AbstractSearchEngineConfigurator.class);
 
+	private ServiceRegistrar<Destination> _destinationServiceRegistrar;
 	private volatile MessageBus _messageBus;
 	private volatile ServiceReference<MessageBus> _messageBusServiceReference;
 	private String _originalSearchEngineId;
 	private final List<SearchEngineRegistration> _searchEngineRegistrations =
 		new ArrayList<>();
 	private Map<String, SearchEngine> _searchEngines;
-	private ServiceRegistrar<Destination> _destinationServiceRegistrar;
 
 	private static class SearchEngineRegistration {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/AbstractSearchEngineConfigurator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/AbstractSearchEngineConfigurator.java
@@ -39,10 +39,12 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
 import com.liferay.registry.ServiceReference;
+import com.liferay.registry.ServiceRegistrar;
 import com.liferay.registry.dependency.ServiceDependencyListener;
 import com.liferay.registry.dependency.ServiceDependencyManager;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -202,6 +204,10 @@ public abstract class AbstractSearchEngineConfigurator
 		_messageBus.removeDestination(
 			searchEngineRegistration.getSearchWriterDestinationName());
 
+		if (_destinationServiceRegistrar != null) {
+			_destinationServiceRegistrar.destroy();
+		}
+
 		SearchEngineHelper searchEngineHelper = getSearchEngineHelper();
 
 		searchEngineHelper.removeSearchEngine(
@@ -358,6 +364,23 @@ public abstract class AbstractSearchEngineConfigurator
 				_messageBus, searchEngineId);
 		}
 
+		Registry registry = RegistryUtil.getRegistry();
+
+		_destinationServiceRegistrar = registry.getServiceRegistrar(
+			Destination.class);
+
+		Map<String, Object> properties = new HashMap<>();
+
+		properties.put("destination.name", searchReaderDestination.getName());
+
+		_destinationServiceRegistrar.registerService(
+			Destination.class, searchReaderDestination, properties);
+
+		properties.put("destination.name", searchWriterDestination.getName());
+
+		_destinationServiceRegistrar.registerService(
+			Destination.class, searchWriterDestination, properties);
+
 		createSearchEngineListeners(
 			searchEngineId, searchEngine, searchReaderDestination,
 			searchWriterDestination);
@@ -452,6 +475,7 @@ public abstract class AbstractSearchEngineConfigurator
 	private final List<SearchEngineRegistration> _searchEngineRegistrations =
 		new ArrayList<>();
 	private Map<String, SearchEngine> _searchEngines;
+	private ServiceRegistrar<Destination> _destinationServiceRegistrar;
 
 	private static class SearchEngineRegistration {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 7.7.1
+version 7.8.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-83420

Hi Mike,

I made changes we discussed 2 weeks ago on Skype with one exception: you said we also needed to unregister the destinations, though according to my tests
- Portal startup-shutdown
- Start & stop default search engine using the App Manager (master/7.1: Elasticsearch 6, 7.0.x: Portal Search Elasticsearch)
- Stop default search engine (App Manager), deploy a new search engine (portal-search-solr), stop the newly deployed search engine and revert back to the default (App Manager)

there were no errors related to Messaging/Destination registrations for "search_reader" and "search_writer" so looks like `_destinationServiceRegistrar.destroy()` is enough.

Let me know if you have any concerns.

Thanks,
Tibor

/cc @istvansajtos @peterpetrekanics