### PR TITLE
[TS] LPS-93762 Reindex does not consider SYSTEM company index: this can prevent index replication on Elasticsearch

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexWriterHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexWriterHelperImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.search.SearchPermissionChecker;
 import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.configuration.IndexWriterHelperConfiguration;
 import com.liferay.portal.search.index.IndexStatusManager;
@@ -489,7 +490,8 @@ public class IndexWriterHelperImpl implements IndexWriterHelper {
 		}
 
 		taskContextMap.put(
-			ReindexBackgroundTaskConstants.COMPANY_IDS, companyIds);
+			ReindexBackgroundTaskConstants.COMPANY_IDS,
+			addSystemCompany(companyIds));
 		taskContextMap.put(
 			BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true);
 
@@ -521,7 +523,8 @@ public class IndexWriterHelperImpl implements IndexWriterHelper {
 		taskContextMap.put(
 			ReindexBackgroundTaskConstants.CLASS_NAME, className);
 		taskContextMap.put(
-			ReindexBackgroundTaskConstants.COMPANY_IDS, companyIds);
+			ReindexBackgroundTaskConstants.COMPANY_IDS,
+			addSystemCompany(companyIds));
 		taskContextMap.put(
 			BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true);
 
@@ -646,6 +649,15 @@ public class IndexWriterHelperImpl implements IndexWriterHelper {
 
 		_commitImmediately =
 			indexWriterHelperConfiguration.indexCommitImmediately();
+	}
+
+	protected long[] addSystemCompany(long[] companyIds) {
+		if (ArrayUtil.contains(companyIds, CompanyConstants.SYSTEM)) {
+			return companyIds;
+		}
+
+		return ArrayUtil.append(
+			new long[] {CompanyConstants.SYSTEM}, companyIds);
 	}
 
 	protected void setCommitImmediately(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-93762

Hey Mike,

**In short**: As of Elasticsearch 5.x, it is not possible to define the values of shards / replicas in "elasticsearch.yml" >>> use `ElasticsearchConfiguration.indexNumberOfReplicas/indexNumberOfShards` >>> both requires to reindex >>> we don't reindex the SYSTEM company index currently >>> this can prevent index replication on Elasticsearch.

I wanted to double-check this with you, because after talking to @BryanEngler we agreed it's a bug, though there may be some specialties around the SYSTEM company we may not take into account.

**Order**: simply appending `CompanyConstants.SYSTEM` to the `companyIds` is not enough, because we need to process the system company first, otherwise I experienced errors (index already exists).

**Test**: we already have `ReplicasManagerImplTest`, though it's relying on the ES Settings API, so not really testing this scenario (changing System Settings), so it's passing even before the fix. (Currently disabled since this [commit](https://github.com/liferay/liferay-portal/commit/5f666bbf05e4b61be1321e6c891aa89ee7b654e0).)

Let us know if you have any concerns.

-
Tibor